### PR TITLE
fix: read config from [mongrator] table written by init

### DIFF
--- a/src/mongrator/config.py
+++ b/src/mongrator/config.py
@@ -30,14 +30,16 @@ class MigratorConfig:
         except tomllib.TOMLDecodeError as e:
             raise ConfigurationError(f"Invalid TOML in {path}: {e}")
 
+        cfg = data.get("mongrator", data)
+
         try:
-            uri: str = data["uri"]
-            database: str = data["database"]
+            uri: str = cfg["uri"]
+            database: str = cfg["database"]
         except KeyError as e:
             raise ConfigurationError(f"Missing required config key: {e}")
 
-        migrations_dir = Path(data.get("migrations_dir", str(_DEFAULT_MIGRATIONS_DIR)))
-        collection: str = data.get("collection", _DEFAULT_COLLECTION)
+        migrations_dir = Path(cfg.get("migrations_dir", str(_DEFAULT_MIGRATIONS_DIR)))
+        collection: str = cfg.get("collection", _DEFAULT_COLLECTION)
         return cls(uri=uri, database=database, migrations_dir=migrations_dir, collection=collection)
 
     @classmethod

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -35,6 +35,30 @@ def test_from_toml_all_keys(tmp_path: Path) -> None:
     assert config.collection == "schema_versions"
 
 
+def test_from_toml_mongrator_table(tmp_path: Path) -> None:
+    cfg_file = tmp_path / "mongrator.toml"
+    cfg_file.write_text('[mongrator]\nuri = "mongodb://localhost:27017"\ndatabase = "mydb"\n')
+    config = MigratorConfig.from_toml(cfg_file)
+    assert config.uri == "mongodb://localhost:27017"
+    assert config.database == "mydb"
+    assert config.migrations_dir == _DEFAULT_MIGRATIONS_DIR
+    assert config.collection == _DEFAULT_COLLECTION
+
+
+def test_from_toml_mongrator_table_all_keys(tmp_path: Path) -> None:
+    cfg_file = tmp_path / "mongrator.toml"
+    cfg_file.write_text(
+        "[mongrator]\n"
+        'uri = "mongodb://host:27017"\n'
+        'database = "prod"\n'
+        'migrations_dir = "db/migrations"\n'
+        'collection = "schema_versions"\n'
+    )
+    config = MigratorConfig.from_toml(cfg_file)
+    assert config.migrations_dir == Path("db/migrations")
+    assert config.collection == "schema_versions"
+
+
 def test_from_toml_missing_uri(tmp_path: Path) -> None:
     cfg_file = tmp_path / "mongrator.toml"
     cfg_file.write_text('database = "mydb"\n')


### PR DESCRIPTION
💁 These changes:

- `init` writes config under a `[mongrator]` TOML table, but `from_toml()` was reading keys from the top level, causing a `ConfigurationError` on any command run after `mongrator init`
- `from_toml()` now checks for a `[mongrator]` table first and falls back to top-level keys for compatibility with existing flat configs
- Two new unit tests cover the `[mongrator]` table format (minimal and full)

## Test plan

- [x] `uv run pytest tests/unit/test_config.py` — all 13 tests pass
- [x] Manual: `mongrator init` → `mongrator status` no longer raises `ConfigurationError`

Fixes #1 