### PR TITLE
ci: upgrade actions/download-artifact to v8.0.1

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,7 +37,7 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/download-artifact@fa0a91b85d4f404e444306234a5f67d04fc7f7fd # v4.1.8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: dist
           path: dist/
@@ -55,7 +55,7 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/download-artifact@fa0a91b85d4f404e444306234a5f67d04fc7f7fd # v4.1.8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: dist
           path: dist/


### PR DESCRIPTION
💁 These changes:

- Bump `actions/download-artifact` from v4.1.8 to v8.0.1 in the publish workflow to fix the following error:

```
Unable to resolve action `actions/download-artifact@fa0a91b85d4f404e444306234a5f67d04fc7f7fd`, unable to find version `fa0a91b85d4f404e444306234a5f67d04fc7f7fd`
```

## Test plan

- [ ] Confirm publish workflow runs successfully on next release