### PR TITLE
fix: Correct project URLs to match repository name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,9 @@ jobs:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
 
+      - name: Check lockfile is up to date
+        run: uv lock --check
+
       - name: Install dependencies
         run: uv sync --group dev
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,10 +39,10 @@ dev = [
 mongrator = "mongrator:main"
 
 [project.urls]
-Homepage = "https://github.com/sgerrand/mongrator"
-Repository = "https://github.com/sgerrand/mongrator"
-"Bug Tracker" = "https://github.com/sgerrand/mongrator/issues"
-Changelog = "https://github.com/sgerrand/mongrator/blob/main/CHANGELOG.md"
+Homepage = "https://github.com/sgerrand/pymongrator"
+Repository = "https://github.com/sgerrand/pymongrator"
+"Bug Tracker" = "https://github.com/sgerrand/pymongrator/issues"
+Changelog = "https://github.com/sgerrand/pymongrator/blob/main/CHANGELOG.md"
 
 [build-system]
 requires = ["uv_build>=0.8.20,<0.9.0"]

--- a/uv.lock
+++ b/uv.lock
@@ -144,7 +144,7 @@ dev = [
     { name = "pytest-asyncio", specifier = ">=0.24" },
     { name = "ruff", specifier = ">=0.9" },
     { name = "testcontainers", extras = ["mongodb"], specifier = ">=4.0" },
-    { name = "ty" },
+    { name = "ty", specifier = ">=0.0.20" },
 ]
 
 [[package]]


### PR DESCRIPTION
💁 These changes:
- Fix project URLs in `pyproject.toml` to point to `sgerrand/pymongrator` instead of `sgerrand/mongrator`
- Update lockfile to reflect `ty` version pin from #5
- Add `uv lock --check` step to CI lint job for lockfile freshness validation

## Test plan
- [x] Verify `uv build` succeeds
- [x] Verify URLs in built package metadata point to the correct repository
- [x] Verify CI lint job passes with new lockfile check step