### PR TITLE
fix(docs): Create HTML output directory before copying site files

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -7,3 +7,6 @@ config:
 globs:
   - "*.md"
   - "docs/*.md"
+
+ignores:
+  - "CHANGELOG.md"

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -11,4 +11,5 @@ build:
     build:
       html:
         - uv run zensical build
+        - mkdir -p $READTHEDOCS_OUTPUT/html
         - cp -r site/. $READTHEDOCS_OUTPUT/html

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -11,5 +11,5 @@ build:
     build:
       html:
         - uv run zensical build
-        - mkdir -p $READTHEDOCS_OUTPUT/html
-        - cp -r site/. $READTHEDOCS_OUTPUT/html
+        - mkdir -p "$READTHEDOCS_OUTPUT/html"
+        - cp -r site/. "$READTHEDOCS_OUTPUT/html"


### PR DESCRIPTION
💁 These changes create the `$READTHEDOCS_OUTPUT/html` directory before copying built site files into it, fixing the build failure where `cp` could not find the target directory.

## Test plan

- [ ] Verify Read the Docs build completes successfully after merge