### PR TITLE
fix: Close MongoClient connections in CLI commands

### DIFF
--- a/src/mongrator/cli.py
+++ b/src/mongrator/cli.py
@@ -116,9 +116,9 @@ def _cmd_status(args: argparse.Namespace) -> int:
         print("error: pymongo is required. Install with: pip install pymongo", file=sys.stderr)
         return 1
 
-    client = pymongo.MongoClient(config.uri)
-    runner = SyncRunner(client, config)
-    statuses = runner.status()
+    with pymongo.MongoClient(config.uri) as client:
+        runner = SyncRunner(client, config)
+        statuses = runner.status()
 
     if not statuses:
         print("No migrations found.")
@@ -144,9 +144,9 @@ def _cmd_up(args: argparse.Namespace) -> int:
 
     from .runner import SyncRunner
 
-    client = pymongo.MongoClient(config.uri)
-    runner = SyncRunner(client, config)
-    applied = runner.up(target=args.target)
+    with pymongo.MongoClient(config.uri) as client:
+        runner = SyncRunner(client, config)
+        applied = runner.up(target=args.target)
     if applied:
         for mid in applied:
             print(f"  applied  {mid}")
@@ -160,9 +160,9 @@ async def _async_up(config: MigratorConfig, target: str | None) -> int:
 
     from .runner import AsyncRunner
 
-    client = AsyncMongoClient(config.uri)
-    runner = AsyncRunner(client, config)
-    applied = await runner.up(target=target)
+    async with AsyncMongoClient(config.uri) as client:
+        runner = AsyncRunner(client, config)
+        applied = await runner.up(target=target)
     if applied:
         for mid in applied:
             print(f"  applied  {mid}")
@@ -179,9 +179,9 @@ def _cmd_down(args: argparse.Namespace) -> int:
 
     from .runner import SyncRunner
 
-    client = pymongo.MongoClient(config.uri)
-    runner = SyncRunner(client, config)
-    rolled_back = runner.down(steps=args.steps)
+    with pymongo.MongoClient(config.uri) as client:
+        runner = SyncRunner(client, config)
+        rolled_back = runner.down(steps=args.steps)
     if rolled_back:
         for mid in rolled_back:
             print(f"  rolled back  {mid}")
@@ -195,9 +195,9 @@ async def _async_down(config: MigratorConfig, steps: int) -> int:
 
     from .runner import AsyncRunner
 
-    client = AsyncMongoClient(config.uri)
-    runner = AsyncRunner(client, config)
-    rolled_back = await runner.down(steps=steps)
+    async with AsyncMongoClient(config.uri) as client:
+        runner = AsyncRunner(client, config)
+        rolled_back = await runner.down(steps=steps)
     if rolled_back:
         for mid in rolled_back:
             print(f"  rolled back  {mid}")
@@ -212,9 +212,9 @@ def _cmd_validate(args: argparse.Namespace) -> int:
     from .runner import SyncRunner
 
     config = _load_config(args)
-    client = pymongo.MongoClient(config.uri)
-    runner = SyncRunner(client, config)
-    errors = runner.validate()
+    with pymongo.MongoClient(config.uri) as client:
+        runner = SyncRunner(client, config)
+        errors = runner.validate()
 
     if not errors:
         print("All applied migrations have valid checksums.")

--- a/src/mongrator/cli.py
+++ b/src/mongrator/cli.py
@@ -156,13 +156,15 @@ def _cmd_up(args: argparse.Namespace) -> int:
 
 
 async def _async_up(config: MigratorConfig, target: str | None) -> int:
+    import pymongo
     from pymongo import AsyncMongoClient
 
     from .runner import AsyncRunner
 
-    async with AsyncMongoClient(config.uri) as client:
-        runner = AsyncRunner(client, config)
-        applied = await runner.up(target=target)
+    with pymongo.MongoClient(config.uri) as sync_client:
+        async with AsyncMongoClient(config.uri) as client:
+            runner = AsyncRunner(client, config, sync_client=sync_client)
+            applied = await runner.up(target=target)
     if applied:
         for mid in applied:
             print(f"  applied  {mid}")
@@ -191,13 +193,15 @@ def _cmd_down(args: argparse.Namespace) -> int:
 
 
 async def _async_down(config: MigratorConfig, steps: int) -> int:
+    import pymongo
     from pymongo import AsyncMongoClient
 
     from .runner import AsyncRunner
 
-    async with AsyncMongoClient(config.uri) as client:
-        runner = AsyncRunner(client, config)
-        rolled_back = await runner.down(steps=steps)
+    with pymongo.MongoClient(config.uri) as sync_client:
+        async with AsyncMongoClient(config.uri) as client:
+            runner = AsyncRunner(client, config, sync_client=sync_client)
+            rolled_back = await runner.down(steps=steps)
     if rolled_back:
         for mid in rolled_back:
             print(f"  rolled back  {mid}")

--- a/src/mongrator/runner.py
+++ b/src/mongrator/runner.py
@@ -150,9 +150,18 @@ class AsyncRunner:
     because ops helpers are synchronous. Only state tracking uses the async client.
     """
 
-    def __init__(self, client: "AsyncMongoClient", config: MigratorConfig) -> None:  # type: ignore[type-arg]
+    def __init__(  # type: ignore[type-arg]
+        self,
+        client: "AsyncMongoClient",
+        config: MigratorConfig,
+        *,
+        sync_client: "MongoClient | None" = None,
+    ) -> None:
         # Sync DB passed to migration functions — ops helpers are synchronous pymongo.
-        self._db = MongoClient(config.uri)[config.database]
+        if sync_client is None:
+            sync_client = MongoClient(config.uri)
+        self._sync_client = sync_client
+        self._db = sync_client[config.database]
         # Async store for non-blocking state tracking.
         async_db = client[config.database]
         self._store = AsyncMongoStateStore(async_db[config.collection])


### PR DESCRIPTION
💁 These changes wrap all `MongoClient` and `AsyncMongoClient` instances in CLI command handlers with context managers (`with`/`async with`) so connections are properly closed — including when exceptions occur during migration execution.

- Sync commands (`status`, `up`, `down`, `validate`) now use `with pymongo.MongoClient(...) as client:`
- Async commands (`_async_up`, `_async_down`) now use `async with AsyncMongoClient(...) as client:`

## Test plan

- [x] Run `uv run pytest tests/unit/test_cli.py` — all parser tests pass
- [x] Run `uv run pytest tests/integration/` — integration tests pass
- [x] Manual: run `mongrator up` and `mongrator down` against a test database