### PR TITLE
feat: Add drop_field, create_collection, and drop_collection ops

### DIFF
--- a/docs/writing-migrations.md
+++ b/docs/writing-migrations.md
@@ -19,12 +19,15 @@ def up(db):
 
 ### Available ops helpers
 
-| Helper                                                         | Reversible | Description                      |
-|----------------------------------------------------------------|------------|----------------------------------|
-| `ops.create_index(collection, keys, **kwargs)`                 | yes        | Create an index                  |
-| `ops.drop_index(collection, index_name)`                       | no         | Drop an index by name            |
-| `ops.rename_field(collection, old, new, filter=None)`          | yes        | Rename a field across documents  |
-| `ops.add_field(collection, field, default_value, filter=None)` | yes        | Add a field with a default value |
+| Helper                                                         | Reversible | Description                          |
+|----------------------------------------------------------------|------------|--------------------------------------|
+| `ops.create_index(collection, keys, **kwargs)`                 | yes        | Create an index                      |
+| `ops.drop_index(collection, index_name)`                       | no         | Drop an index by name                |
+| `ops.rename_field(collection, old, new, filter=None)`          | yes        | Rename a field across documents      |
+| `ops.add_field(collection, field, default_value, filter=None)` | yes        | Add a field with a default value     |
+| `ops.drop_field(collection, field, filter=None)`               | no         | Remove a field from documents        |
+| `ops.create_collection(collection, **kwargs)`                  | yes        | Create a collection (reverts by drop)|
+| `ops.drop_collection(collection)`                              | no         | Drop a collection                    |
 
 See the [ops API reference](api/ops.md) for full details.
 

--- a/src/mongrator/ops.py
+++ b/src/mongrator/ops.py
@@ -126,3 +126,64 @@ def add_field(
         _apply=apply,
         _revert=revert,
     )
+
+
+def drop_field(
+    collection: str,
+    field_name: str,
+    filter: dict[str, Any] | None = None,
+) -> Operation:
+    """Remove a field from all (or filtered) documents. Not auto-reversible
+    because the original values are lost.
+    """
+    query = filter or {}
+
+    def apply(db: Database) -> None:  # type: ignore[type-arg]
+        db[collection].update_many(query, {"$unset": {field_name: ""}})
+
+    def revert(db: Database) -> None:  # type: ignore[type-arg]
+        raise NotImplementedError(
+            f"drop_field({collection!r}, {field_name!r}) cannot be auto-reverted. "
+            "Define a down() function to restore the field."
+        )
+
+    return Operation(
+        description=f"drop_field({collection!r}, {field_name!r})",
+        _apply=apply,
+        _revert=revert,
+    )
+
+
+def create_collection(collection: str, **kwargs: Any) -> Operation:
+    """Create a collection. Reverts by dropping it."""
+
+    def apply(db: Database) -> None:  # type: ignore[type-arg]
+        db.create_collection(collection, **kwargs)
+
+    def revert(db: Database) -> None:  # type: ignore[type-arg]
+        db.drop_collection(collection)
+
+    return Operation(
+        description=f"create_collection({collection!r})",
+        _apply=apply,
+        _revert=revert,
+    )
+
+
+def drop_collection(collection: str) -> Operation:
+    """Drop a collection. Not auto-reversible because the data is lost."""
+
+    def apply(db: Database) -> None:  # type: ignore[type-arg]
+        db.drop_collection(collection)
+
+    def revert(db: Database) -> None:  # type: ignore[type-arg]
+        raise NotImplementedError(
+            f"drop_collection({collection!r}) cannot be auto-reverted. "
+            "Define a down() function to recreate the collection."
+        )
+
+    return Operation(
+        description=f"drop_collection({collection!r})",
+        _apply=apply,
+        _revert=revert,
+    )

--- a/src/mongrator/ops.py
+++ b/src/mongrator/ops.py
@@ -167,7 +167,10 @@ def create_collection(collection: str, **kwargs: Any) -> Operation:
         db.drop_collection(collection)
 
     return Operation(
-        description=f"create_collection({collection!r})",
+        description="create_collection({!r}{})".format(
+            collection,
+            ", " + ", ".join(f"{k}={v!r}" for k, v in kwargs.items()) if kwargs else "",
+        ),
         _apply=apply,
         _revert=revert,
     )

--- a/src/mongrator/ops.py
+++ b/src/mongrator/ops.py
@@ -139,7 +139,10 @@ def drop_field(
     query = filter or {}
 
     def apply(db: Database) -> None:  # type: ignore[type-arg]
-        db[collection].update_many(query, {"$unset": {field_name: ""}})
+        db[collection].update_many(
+            {**query, field_name: {"$exists": True}},
+            {"$unset": {field_name: ""}},
+        )
 
     def revert(db: Database) -> None:  # type: ignore[type-arg]
         raise NotImplementedError(

--- a/tests/unit/test_ops.py
+++ b/tests/unit/test_ops.py
@@ -4,7 +4,16 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from mongrator.ops import Operation, add_field, create_index, drop_index, rename_field
+from mongrator.ops import (
+    Operation,
+    add_field,
+    create_collection,
+    create_index,
+    drop_collection,
+    drop_field,
+    drop_index,
+    rename_field,
+)
 
 
 def _db() -> MagicMock:
@@ -180,3 +189,92 @@ def test_add_field_revert_with_filter() -> None:
     op = add_field("users", "verified", False, filter={"role": "admin"})
     op.revert(db)
     db["users"].update_many.assert_called_once_with({"role": "admin"}, {"$unset": {"verified": ""}})
+
+
+# ---------------------------------------------------------------------------
+# drop_field
+# ---------------------------------------------------------------------------
+
+
+def test_drop_field_description() -> None:
+    op = drop_field("users", "legacy_flag")
+    assert "drop_field" in op.description
+    assert "legacy_flag" in op.description
+
+
+def test_drop_field_apply() -> None:
+    db = _db()
+    op = drop_field("users", "legacy_flag")
+    op.apply(db)
+    db["users"].update_many.assert_called_once_with({}, {"$unset": {"legacy_flag": ""}})
+
+
+def test_drop_field_apply_with_filter() -> None:
+    db = _db()
+    op = drop_field("users", "legacy_flag", filter={"active": False})
+    op.apply(db)
+    db["users"].update_many.assert_called_once_with({"active": False}, {"$unset": {"legacy_flag": ""}})
+
+
+def test_drop_field_revert_raises() -> None:
+    db = _db()
+    op = drop_field("users", "legacy_flag")
+    with pytest.raises(NotImplementedError):
+        op.revert(db)
+
+
+# ---------------------------------------------------------------------------
+# create_collection
+# ---------------------------------------------------------------------------
+
+
+def test_create_collection_description() -> None:
+    op = create_collection("audit_log")
+    assert "create_collection" in op.description
+    assert "audit_log" in op.description
+
+
+def test_create_collection_apply() -> None:
+    db = _db()
+    op = create_collection("audit_log")
+    op.apply(db)
+    db.create_collection.assert_called_once_with("audit_log")
+
+
+def test_create_collection_apply_with_kwargs() -> None:
+    db = _db()
+    op = create_collection("audit_log", capped=True, size=1048576)
+    op.apply(db)
+    db.create_collection.assert_called_once_with("audit_log", capped=True, size=1048576)
+
+
+def test_create_collection_revert_drops() -> None:
+    db = _db()
+    op = create_collection("audit_log")
+    op.revert(db)
+    db.drop_collection.assert_called_once_with("audit_log")
+
+
+# ---------------------------------------------------------------------------
+# drop_collection
+# ---------------------------------------------------------------------------
+
+
+def test_drop_collection_description() -> None:
+    op = drop_collection("old_logs")
+    assert "drop_collection" in op.description
+    assert "old_logs" in op.description
+
+
+def test_drop_collection_apply() -> None:
+    db = _db()
+    op = drop_collection("old_logs")
+    op.apply(db)
+    db.drop_collection.assert_called_once_with("old_logs")
+
+
+def test_drop_collection_revert_raises() -> None:
+    db = _db()
+    op = drop_collection("old_logs")
+    with pytest.raises(NotImplementedError):
+        op.revert(db)

--- a/tests/unit/test_ops.py
+++ b/tests/unit/test_ops.py
@@ -206,14 +206,16 @@ def test_drop_field_apply() -> None:
     db = _db()
     op = drop_field("users", "legacy_flag")
     op.apply(db)
-    db["users"].update_many.assert_called_once_with({}, {"$unset": {"legacy_flag": ""}})
+    db["users"].update_many.assert_called_once_with({"legacy_flag": {"$exists": True}}, {"$unset": {"legacy_flag": ""}})
 
 
 def test_drop_field_apply_with_filter() -> None:
     db = _db()
     op = drop_field("users", "legacy_flag", filter={"active": False})
     op.apply(db)
-    db["users"].update_many.assert_called_once_with({"active": False}, {"$unset": {"legacy_flag": ""}})
+    db["users"].update_many.assert_called_once_with(
+        {"active": False, "legacy_flag": {"$exists": True}}, {"$unset": {"legacy_flag": ""}}
+    )
 
 
 def test_drop_field_revert_raises() -> None:

--- a/tests/unit/test_ops.py
+++ b/tests/unit/test_ops.py
@@ -243,6 +243,12 @@ def test_create_collection_apply() -> None:
     db.create_collection.assert_called_once_with("audit_log")
 
 
+def test_create_collection_description_with_kwargs() -> None:
+    op = create_collection("audit_log", capped=True, size=1048576)
+    assert "capped=True" in op.description
+    assert "size=1048576" in op.description
+
+
 def test_create_collection_apply_with_kwargs() -> None:
     db = _db()
     op = create_collection("audit_log", capped=True, size=1048576)


### PR DESCRIPTION
💁 These changes expand the declarative ops helpers with three new operations:

- `ops.drop_field(collection, field, filter=None)` — removes a field from documents (not auto-reversible, data is lost)
- `ops.create_collection(collection, **kwargs)` — creates a collection, reverts by dropping it
- `ops.drop_collection(collection)` — drops a collection (not auto-reversible, data is lost)

Also updates the writing-migrations documentation with the new ops table.

## Test plan

- [x] Run `uv run pytest tests/unit/test_ops.py` — all 31 tests pass
- [x] Verify docs table renders correctly in `docs/writing-migrations.md`