### PR TITLE
feat: Add advisory locking to prevent concurrent migrations

### DIFF
--- a/src/mongrator/exceptions.py
+++ b/src/mongrator/exceptions.py
@@ -63,3 +63,14 @@ class MigrationNotFoundError(MigratorError):
     def __init__(self, migration_id: str) -> None:
         self.migration_id = migration_id
         super().__init__(f"Migration not found: '{migration_id}'")
+
+
+class MigrationLockError(MigratorError):
+    """Could not acquire the migration lock."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            "Could not acquire migration lock. "
+            "Another migration may be in progress. "
+            "If this is stale, the lock will expire automatically."
+        )

--- a/src/mongrator/exceptions.py
+++ b/src/mongrator/exceptions.py
@@ -65,6 +65,16 @@ class MigrationNotFoundError(MigratorError):
         super().__init__(f"Migration not found: '{migration_id}'")
 
 
+class ReservedMigrationIdError(MigratorError):
+    """A migration file uses a reserved internal ID."""
+
+    def __init__(self, migration_id: str) -> None:
+        self.migration_id = migration_id
+        super().__init__(
+            f"Migration ID '{migration_id}' is reserved for internal use. Please rename the migration file."
+        )
+
+
 class MigrationLockError(MigratorError):
     """Could not acquire the migration lock."""
 

--- a/src/mongrator/loader.py
+++ b/src/mongrator/loader.py
@@ -9,8 +9,10 @@ from .exceptions import (
     DuplicateMigrationIdError,
     InvalidMigrationFileError,
     MigrationImportError,
+    ReservedMigrationIdError,
 )
 from .migration import Checksum, MigrationFile, MigrationId
+from .state import RESERVED_IDS
 
 
 def _checksum(path: Path) -> Checksum:
@@ -43,6 +45,8 @@ def load(config: MigratorConfig) -> list[MigrationFile]:
     for path in paths:
         migration_id = _migration_id(path)
 
+        if migration_id in RESERVED_IDS:
+            raise ReservedMigrationIdError(migration_id)
         if migration_id in seen:
             raise DuplicateMigrationIdError(migration_id)
         seen[migration_id] = path

--- a/src/mongrator/runner.py
+++ b/src/mongrator/runner.py
@@ -17,7 +17,7 @@ from .exceptions import ChecksumMismatchError, NoDownMethodError
 from .migration import MigrationFile, MigrationId, MigrationStatus
 from .ops import Operation
 from .planner import MigrationPlan
-from .state import AsyncMongoStateStore, SyncStateStore, make_record
+from .state import AsyncMigrationLock, AsyncMongoStateStore, SyncMigrationLock, SyncStateStore, make_record
 
 
 @runtime_checkable
@@ -86,6 +86,7 @@ class SyncRunner:
     def __init__(self, client: "MongoClient", config: MigratorConfig) -> None:  # type: ignore[type-arg]
         self._db = client[config.database]
         self._store = SyncStateStore(self._db[config.collection])
+        self._lock = SyncMigrationLock(self._db[config.collection])
         self._config = config
 
     def plan_up(self, target: MigrationId | None = None) -> MigrationPlan:
@@ -102,31 +103,33 @@ class SyncRunner:
 
     def up(self, target: MigrationId | None = None) -> list[MigrationId]:
         """Apply pending migrations, optionally up to `target`."""
-        files = loader.load(self._config)
-        applied = self._store.get_applied()
-        plan = planner.plan_up(files, applied, target)
-        applied_ids: list[MigrationId] = []
-        for migration in plan.to_apply:
-            start = time.monotonic()
-            _run_up_migration(migration, self._db)
-            duration_ms = int((time.monotonic() - start) * 1000)
-            self._store.record_applied(make_record(migration.id, migration.checksum, "up", duration_ms))
-            applied_ids.append(migration.id)
-        return applied_ids
+        with self._lock:
+            files = loader.load(self._config)
+            applied = self._store.get_applied()
+            plan = planner.plan_up(files, applied, target)
+            applied_ids: list[MigrationId] = []
+            for migration in plan.to_apply:
+                start = time.monotonic()
+                _run_up_migration(migration, self._db)
+                duration_ms = int((time.monotonic() - start) * 1000)
+                self._store.record_applied(make_record(migration.id, migration.checksum, "up", duration_ms))
+                applied_ids.append(migration.id)
+            return applied_ids
 
     def down(self, steps: int = 1) -> list[MigrationId]:
         """Roll back the most recently applied migrations."""
-        files = loader.load(self._config)
-        applied = self._store.get_applied()
-        plan = planner.plan_down(files, applied, steps)
-        rolled_back: list[MigrationId] = []
-        for migration in plan.to_apply:
-            start = time.monotonic()
-            _run_down_migration(migration, self._db)
-            duration_ms = int((time.monotonic() - start) * 1000)
-            self._store.record_applied(make_record(migration.id, migration.checksum, "down", duration_ms))
-            rolled_back.append(migration.id)
-        return rolled_back
+        with self._lock:
+            files = loader.load(self._config)
+            applied = self._store.get_applied()
+            plan = planner.plan_down(files, applied, steps)
+            rolled_back: list[MigrationId] = []
+            for migration in plan.to_apply:
+                start = time.monotonic()
+                _run_down_migration(migration, self._db)
+                duration_ms = int((time.monotonic() - start) * 1000)
+                self._store.record_applied(make_record(migration.id, migration.checksum, "down", duration_ms))
+                rolled_back.append(migration.id)
+            return rolled_back
 
     def status(self) -> list[MigrationStatus]:
         """Return the status of every known migration."""
@@ -182,6 +185,7 @@ class AsyncRunner:
         # Async store for non-blocking state tracking.
         async_db = client[config.database]
         self._store = AsyncMongoStateStore(async_db[config.collection])
+        self._lock = AsyncMigrationLock(async_db[config.collection])
         self._config = config
 
     async def plan_up(self, target: MigrationId | None = None) -> MigrationPlan:
@@ -198,31 +202,33 @@ class AsyncRunner:
 
     async def up(self, target: MigrationId | None = None) -> list[MigrationId]:
         """Apply pending migrations, optionally up to `target`."""
-        files = loader.load(self._config)
-        applied = await self._store.get_applied()
-        plan = planner.plan_up(files, applied, target)
-        applied_ids: list[MigrationId] = []
-        for migration in plan.to_apply:
-            start = time.monotonic()
-            _run_up_migration(migration, self._db)
-            duration_ms = int((time.monotonic() - start) * 1000)
-            await self._store.record_applied(make_record(migration.id, migration.checksum, "up", duration_ms))
-            applied_ids.append(migration.id)
-        return applied_ids
+        async with self._lock:
+            files = loader.load(self._config)
+            applied = await self._store.get_applied()
+            plan = planner.plan_up(files, applied, target)
+            applied_ids: list[MigrationId] = []
+            for migration in plan.to_apply:
+                start = time.monotonic()
+                _run_up_migration(migration, self._db)
+                duration_ms = int((time.monotonic() - start) * 1000)
+                await self._store.record_applied(make_record(migration.id, migration.checksum, "up", duration_ms))
+                applied_ids.append(migration.id)
+            return applied_ids
 
     async def down(self, steps: int = 1) -> list[MigrationId]:
         """Roll back the most recently applied migrations."""
-        files = loader.load(self._config)
-        applied = await self._store.get_applied()
-        plan = planner.plan_down(files, applied, steps)
-        rolled_back: list[MigrationId] = []
-        for migration in plan.to_apply:
-            start = time.monotonic()
-            _run_down_migration(migration, self._db)
-            duration_ms = int((time.monotonic() - start) * 1000)
-            await self._store.record_applied(make_record(migration.id, migration.checksum, "down", duration_ms))
-            rolled_back.append(migration.id)
-        return rolled_back
+        async with self._lock:
+            files = loader.load(self._config)
+            applied = await self._store.get_applied()
+            plan = planner.plan_down(files, applied, steps)
+            rolled_back: list[MigrationId] = []
+            for migration in plan.to_apply:
+                start = time.monotonic()
+                _run_down_migration(migration, self._db)
+                duration_ms = int((time.monotonic() - start) * 1000)
+                await self._store.record_applied(make_record(migration.id, migration.checksum, "down", duration_ms))
+                rolled_back.append(migration.id)
+            return rolled_back
 
     async def status(self) -> list[MigrationStatus]:
         """Return the status of every known migration."""

--- a/src/mongrator/state.py
+++ b/src/mongrator/state.py
@@ -12,6 +12,7 @@ The tracking collection stores one document per applied migration::
 """
 
 import os
+import platform
 from datetime import UTC, datetime, timedelta
 from typing import Literal, Protocol, runtime_checkable
 
@@ -111,7 +112,7 @@ class SyncMigrationLock:
             {
                 "$set": {
                     "locked": True,
-                    "locked_by": f"{os.getpid()}@{os.uname().nodename}",
+                    "locked_by": f"{os.getpid()}@{platform.node()}",
                     "locked_at": now,
                     "expires_at": now + _LOCK_TTL,
                 },
@@ -151,7 +152,7 @@ class AsyncMigrationLock:
             {
                 "$set": {
                     "locked": True,
-                    "locked_by": f"{os.getpid()}@{os.uname().nodename}",
+                    "locked_by": f"{os.getpid()}@{platform.node()}",
                     "locked_at": now,
                     "expires_at": now + _LOCK_TTL,
                 },

--- a/src/mongrator/state.py
+++ b/src/mongrator/state.py
@@ -11,13 +11,18 @@ The tracking collection stores one document per applied migration::
     }
 """
 
-from datetime import UTC, datetime
+import os
+from datetime import UTC, datetime, timedelta
 from typing import Literal, Protocol, runtime_checkable
 
 from pymongo.asynchronous.collection import AsyncCollection
 from pymongo.collection import Collection
 
+from .exceptions import MigrationLockError
 from .migration import MigrationId, MigrationRecord
+
+_LOCK_ID = "_mongrator_lock"
+_LOCK_TTL = timedelta(minutes=10)
 
 
 @runtime_checkable
@@ -83,6 +88,90 @@ class AsyncMongoStateStore:
 
     async def get_record(self, migration_id: MigrationId) -> MigrationRecord | None:
         return await self._col.find_one({"_id": migration_id})  # type: ignore[return-value]
+
+
+class SyncMigrationLock:
+    """Advisory lock using a document in the tracking collection.
+
+    Prevents concurrent migration runs. The lock expires automatically
+    after a TTL to handle crashes or abandoned processes.
+    """
+
+    def __init__(self, collection: "Collection") -> None:  # type: ignore[type-arg]
+        self._col = collection
+
+    def acquire(self) -> None:
+        """Acquire the lock or raise MigrationLockError."""
+        now = datetime.now(tz=UTC)
+        result = self._col.find_one_and_update(
+            {
+                "_id": _LOCK_ID,
+                "$or": [{"locked": False}, {"expires_at": {"$lt": now}}],
+            },
+            {
+                "$set": {
+                    "locked": True,
+                    "locked_by": f"{os.getpid()}@{os.uname().nodename}",
+                    "locked_at": now,
+                    "expires_at": now + _LOCK_TTL,
+                },
+            },
+            upsert=True,
+            return_document=True,
+        )
+        if result is None:
+            raise MigrationLockError
+
+    def release(self) -> None:
+        """Release the lock."""
+        self._col.update_one({"_id": _LOCK_ID}, {"$set": {"locked": False}})
+
+    def __enter__(self) -> "SyncMigrationLock":
+        self.acquire()
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        self.release()
+
+
+class AsyncMigrationLock:
+    """Async advisory lock using a document in the tracking collection."""
+
+    def __init__(self, collection: "AsyncCollection") -> None:  # type: ignore[type-arg]
+        self._col = collection
+
+    async def acquire(self) -> None:
+        """Acquire the lock or raise MigrationLockError."""
+        now = datetime.now(tz=UTC)
+        result = await self._col.find_one_and_update(
+            {
+                "_id": _LOCK_ID,
+                "$or": [{"locked": False}, {"expires_at": {"$lt": now}}],
+            },
+            {
+                "$set": {
+                    "locked": True,
+                    "locked_by": f"{os.getpid()}@{os.uname().nodename}",
+                    "locked_at": now,
+                    "expires_at": now + _LOCK_TTL,
+                },
+            },
+            upsert=True,
+            return_document=True,
+        )
+        if result is None:
+            raise MigrationLockError
+
+    async def release(self) -> None:
+        """Release the lock."""
+        await self._col.update_one({"_id": _LOCK_ID}, {"$set": {"locked": False}})
+
+    async def __aenter__(self) -> "AsyncMigrationLock":
+        await self.acquire()
+        return self
+
+    async def __aexit__(self, *args: object) -> None:
+        await self.release()
 
 
 def make_record(

--- a/src/mongrator/state.py
+++ b/src/mongrator/state.py
@@ -18,6 +18,7 @@ from typing import Literal, Protocol, runtime_checkable
 
 from pymongo.asynchronous.collection import AsyncCollection
 from pymongo.collection import Collection
+from pymongo.errors import DuplicateKeyError
 
 from .exceptions import MigrationLockError
 from .migration import MigrationId, MigrationRecord
@@ -104,22 +105,25 @@ class SyncMigrationLock:
     def acquire(self) -> None:
         """Acquire the lock or raise MigrationLockError."""
         now = datetime.now(tz=UTC)
-        result = self._col.find_one_and_update(
-            {
-                "_id": _LOCK_ID,
-                "$or": [{"locked": False}, {"expires_at": {"$lt": now}}],
-            },
-            {
-                "$set": {
-                    "locked": True,
-                    "locked_by": f"{os.getpid()}@{platform.node()}",
-                    "locked_at": now,
-                    "expires_at": now + _LOCK_TTL,
+        try:
+            result = self._col.find_one_and_update(
+                {
+                    "_id": _LOCK_ID,
+                    "$or": [{"locked": False}, {"expires_at": {"$lt": now}}],
                 },
-            },
-            upsert=True,
-            return_document=True,
-        )
+                {
+                    "$set": {
+                        "locked": True,
+                        "locked_by": f"{os.getpid()}@{platform.node()}",
+                        "locked_at": now,
+                        "expires_at": now + _LOCK_TTL,
+                    },
+                },
+                upsert=True,
+                return_document=True,
+            )
+        except DuplicateKeyError:
+            raise MigrationLockError from None
         if result is None:
             raise MigrationLockError
 
@@ -144,22 +148,25 @@ class AsyncMigrationLock:
     async def acquire(self) -> None:
         """Acquire the lock or raise MigrationLockError."""
         now = datetime.now(tz=UTC)
-        result = await self._col.find_one_and_update(
-            {
-                "_id": _LOCK_ID,
-                "$or": [{"locked": False}, {"expires_at": {"$lt": now}}],
-            },
-            {
-                "$set": {
-                    "locked": True,
-                    "locked_by": f"{os.getpid()}@{platform.node()}",
-                    "locked_at": now,
-                    "expires_at": now + _LOCK_TTL,
+        try:
+            result = await self._col.find_one_and_update(
+                {
+                    "_id": _LOCK_ID,
+                    "$or": [{"locked": False}, {"expires_at": {"$lt": now}}],
                 },
-            },
-            upsert=True,
-            return_document=True,
-        )
+                {
+                    "$set": {
+                        "locked": True,
+                        "locked_by": f"{os.getpid()}@{platform.node()}",
+                        "locked_at": now,
+                        "expires_at": now + _LOCK_TTL,
+                    },
+                },
+                upsert=True,
+                return_document=True,
+            )
+        except DuplicateKeyError:
+            raise MigrationLockError from None
         if result is None:
             raise MigrationLockError
 

--- a/src/mongrator/state.py
+++ b/src/mongrator/state.py
@@ -24,6 +24,7 @@ from .exceptions import MigrationLockError
 from .migration import MigrationId, MigrationRecord
 
 _LOCK_ID = "_mongrator_lock"
+RESERVED_IDS: frozenset[str] = frozenset({_LOCK_ID})
 _LOCK_TTL = timedelta(minutes=10)
 
 

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -8,6 +8,7 @@ from mongrator.exceptions import (
     DuplicateMigrationIdError,
     InvalidMigrationFileError,
     MigrationImportError,
+    MigrationLockError,
     MigrationNotFoundError,
     MigratorError,
     NoDownMethodError,
@@ -23,6 +24,7 @@ def test_all_errors_are_migrator_errors() -> None:
         InvalidMigrationFileError,
         NoDownMethodError,
         MigrationNotFoundError,
+        MigrationLockError,
     ):
         assert issubclass(cls, MigratorError)
 
@@ -68,6 +70,12 @@ def test_migration_not_found_attributes() -> None:
     err = MigrationNotFoundError("999_missing")
     assert err.migration_id == "999_missing"
     assert "999_missing" in str(err)
+
+
+def test_migration_lock_error() -> None:
+    err = MigrationLockError()
+    assert "lock" in str(err).lower()
+    assert isinstance(err, MigratorError)
 
 
 def test_errors_are_catchable_as_base() -> None:

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from mongrator.config import MigratorConfig
-from mongrator.exceptions import NoDownMethodError
+from mongrator.exceptions import MigrationLockError, NoDownMethodError
 from mongrator.migration import MigrationFile
 from mongrator.ops import create_index
 from mongrator.runner import AsyncRunner, SyncRunner
@@ -384,6 +384,104 @@ async def test_async_plan_up_returns_pending(tmp_path: Path) -> None:
 
     assert [m.id for m in plan.to_apply] == ["002_b"]
     assert [m.id for m in plan.to_skip] == ["001_a"]
+    store.record_applied.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# SyncRunner lock usage
+# ---------------------------------------------------------------------------
+
+
+def test_sync_up_acquires_and_releases_lock(tmp_path: Path) -> None:
+    runner, db, store = _sync_runner(tmp_path)
+    store.get_applied.return_value = set()
+
+    with patch("mongrator.runner.loader.load", return_value=[_migration("001_a")]):
+        runner.up()
+
+    runner._lock.__enter__.assert_called_once()
+    runner._lock.__exit__.assert_called_once()
+
+
+def test_sync_down_acquires_and_releases_lock(tmp_path: Path) -> None:
+    runner, db, store = _sync_runner(tmp_path)
+    store.get_applied.return_value = {"001_a"}
+
+    with patch("mongrator.runner.loader.load", return_value=[_migration("001_a", has_down=True)]):
+        runner.down()
+
+    runner._lock.__enter__.assert_called_once()
+    runner._lock.__exit__.assert_called_once()
+
+
+def test_sync_up_propagates_lock_error(tmp_path: Path) -> None:
+    runner, db, store = _sync_runner(tmp_path)
+    runner._lock.__enter__.side_effect = MigrationLockError()
+
+    with pytest.raises(MigrationLockError):
+        runner.up()
+
+    store.record_applied.assert_not_called()
+
+
+def test_sync_down_propagates_lock_error(tmp_path: Path) -> None:
+    runner, db, store = _sync_runner(tmp_path)
+    runner._lock.__enter__.side_effect = MigrationLockError()
+
+    with pytest.raises(MigrationLockError):
+        runner.down()
+
+    store.record_applied.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# AsyncRunner lock usage
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_async_up_acquires_and_releases_lock(tmp_path: Path) -> None:
+    runner, db, store = _async_runner(tmp_path)
+    store.get_applied.return_value = set()
+
+    with patch("mongrator.runner.loader.load", return_value=[_migration("001_a")]):
+        await runner.up()
+
+    runner._lock.__aenter__.assert_called_once()
+    runner._lock.__aexit__.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_async_down_acquires_and_releases_lock(tmp_path: Path) -> None:
+    runner, db, store = _async_runner(tmp_path)
+    store.get_applied.return_value = {"001_a"}
+
+    with patch("mongrator.runner.loader.load", return_value=[_migration("001_a", has_down=True)]):
+        await runner.down()
+
+    runner._lock.__aenter__.assert_called_once()
+    runner._lock.__aexit__.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_async_up_propagates_lock_error(tmp_path: Path) -> None:
+    runner, db, store = _async_runner(tmp_path)
+    runner._lock.__aenter__.side_effect = MigrationLockError()
+
+    with pytest.raises(MigrationLockError):
+        await runner.up()
+
+    store.record_applied.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_async_down_propagates_lock_error(tmp_path: Path) -> None:
+    runner, db, store = _async_runner(tmp_path)
+    runner._lock.__aenter__.side_effect = MigrationLockError()
+
+    with pytest.raises(MigrationLockError):
+        await runner.down()
+
     store.record_applied.assert_not_called()
 
 

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -43,6 +43,7 @@ def _sync_runner(tmp_path: Path) -> tuple[SyncRunner, MagicMock, MagicMock]:
     config = _config(tmp_path)
     runner = SyncRunner(mock_client, config)
     runner._store = mock_store
+    runner._lock = MagicMock()
     return runner, mock_db, mock_store
 
 
@@ -55,6 +56,7 @@ def _async_runner(tmp_path: Path) -> tuple[AsyncRunner, MagicMock, AsyncMock]:
     config = _config(tmp_path)
     runner = AsyncRunner(mock_client, config)
     runner._store = mock_store
+    runner._lock = AsyncMock()
     return runner, mock_db, mock_store
 
 

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -399,8 +399,8 @@ def test_sync_up_acquires_and_releases_lock(tmp_path: Path) -> None:
     with patch("mongrator.runner.loader.load", return_value=[_migration("001_a")]):
         runner.up()
 
-    runner._lock.__enter__.assert_called_once()
-    runner._lock.__exit__.assert_called_once()
+    runner._lock.__enter__.assert_called_once()  # ty: ignore[unresolved-attribute]
+    runner._lock.__exit__.assert_called_once()  # ty: ignore[unresolved-attribute]
 
 
 def test_sync_down_acquires_and_releases_lock(tmp_path: Path) -> None:
@@ -410,13 +410,13 @@ def test_sync_down_acquires_and_releases_lock(tmp_path: Path) -> None:
     with patch("mongrator.runner.loader.load", return_value=[_migration("001_a", has_down=True)]):
         runner.down()
 
-    runner._lock.__enter__.assert_called_once()
-    runner._lock.__exit__.assert_called_once()
+    runner._lock.__enter__.assert_called_once()  # ty: ignore[unresolved-attribute]
+    runner._lock.__exit__.assert_called_once()  # ty: ignore[unresolved-attribute]
 
 
 def test_sync_up_propagates_lock_error(tmp_path: Path) -> None:
     runner, db, store = _sync_runner(tmp_path)
-    runner._lock.__enter__.side_effect = MigrationLockError()
+    runner._lock.__enter__.side_effect = MigrationLockError()  # ty: ignore[invalid-assignment]
 
     with pytest.raises(MigrationLockError):
         runner.up()
@@ -426,7 +426,7 @@ def test_sync_up_propagates_lock_error(tmp_path: Path) -> None:
 
 def test_sync_down_propagates_lock_error(tmp_path: Path) -> None:
     runner, db, store = _sync_runner(tmp_path)
-    runner._lock.__enter__.side_effect = MigrationLockError()
+    runner._lock.__enter__.side_effect = MigrationLockError()  # ty: ignore[invalid-assignment]
 
     with pytest.raises(MigrationLockError):
         runner.down()
@@ -447,8 +447,8 @@ async def test_async_up_acquires_and_releases_lock(tmp_path: Path) -> None:
     with patch("mongrator.runner.loader.load", return_value=[_migration("001_a")]):
         await runner.up()
 
-    runner._lock.__aenter__.assert_called_once()
-    runner._lock.__aexit__.assert_called_once()
+    runner._lock.__aenter__.assert_called_once()  # ty: ignore[unresolved-attribute]
+    runner._lock.__aexit__.assert_called_once()  # ty: ignore[unresolved-attribute]
 
 
 @pytest.mark.asyncio
@@ -459,14 +459,14 @@ async def test_async_down_acquires_and_releases_lock(tmp_path: Path) -> None:
     with patch("mongrator.runner.loader.load", return_value=[_migration("001_a", has_down=True)]):
         await runner.down()
 
-    runner._lock.__aenter__.assert_called_once()
-    runner._lock.__aexit__.assert_called_once()
+    runner._lock.__aenter__.assert_called_once()  # ty: ignore[unresolved-attribute]
+    runner._lock.__aexit__.assert_called_once()  # ty: ignore[unresolved-attribute]
 
 
 @pytest.mark.asyncio
 async def test_async_up_propagates_lock_error(tmp_path: Path) -> None:
     runner, db, store = _async_runner(tmp_path)
-    runner._lock.__aenter__.side_effect = MigrationLockError()
+    runner._lock.__aenter__.side_effect = MigrationLockError()  # ty: ignore[invalid-assignment]
 
     with pytest.raises(MigrationLockError):
         await runner.up()
@@ -477,7 +477,7 @@ async def test_async_up_propagates_lock_error(tmp_path: Path) -> None:
 @pytest.mark.asyncio
 async def test_async_down_propagates_lock_error(tmp_path: Path) -> None:
     runner, db, store = _async_runner(tmp_path)
-    runner._lock.__aenter__.side_effect = MigrationLockError()
+    runner._lock.__aenter__.side_effect = MigrationLockError()  # ty: ignore[invalid-assignment]
 
     with pytest.raises(MigrationLockError):
         await runner.down()

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -5,7 +5,14 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from mongrator.state import AsyncMongoStateStore, SyncStateStore, make_record
+from mongrator.exceptions import MigrationLockError
+from mongrator.state import (
+    AsyncMigrationLock,
+    AsyncMongoStateStore,
+    SyncMigrationLock,
+    SyncStateStore,
+    make_record,
+)
 
 # ---------------------------------------------------------------------------
 # make_record
@@ -159,3 +166,85 @@ async def test_async_get_record_not_found() -> None:
     store, col = _async_store()
     col.find_one.return_value = None
     assert await store.get_record("999_missing") is None
+
+
+# ---------------------------------------------------------------------------
+# SyncMigrationLock
+# ---------------------------------------------------------------------------
+
+
+def test_sync_lock_acquire_success() -> None:
+    col = MagicMock()
+    col.find_one_and_update.return_value = {"_id": "_mongrator_lock", "locked": True}
+    lock = SyncMigrationLock(col)
+    lock.acquire()
+    col.find_one_and_update.assert_called_once()
+
+
+def test_sync_lock_acquire_fails_when_held() -> None:
+    col = MagicMock()
+    col.find_one_and_update.return_value = None
+    lock = SyncMigrationLock(col)
+    with pytest.raises(MigrationLockError):
+        lock.acquire()
+
+
+def test_sync_lock_release() -> None:
+    col = MagicMock()
+    lock = SyncMigrationLock(col)
+    lock.release()
+    col.update_one.assert_called_once()
+
+
+def test_sync_lock_context_manager() -> None:
+    col = MagicMock()
+    col.find_one_and_update.return_value = {"_id": "_mongrator_lock", "locked": True}
+    lock = SyncMigrationLock(col)
+    with lock:
+        pass
+    col.find_one_and_update.assert_called_once()
+    col.update_one.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# AsyncMigrationLock
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_async_lock_acquire_success() -> None:
+    col = MagicMock()
+    col.find_one_and_update = AsyncMock(return_value={"_id": "_mongrator_lock", "locked": True})
+    lock = AsyncMigrationLock(col)
+    await lock.acquire()
+    col.find_one_and_update.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_async_lock_acquire_fails_when_held() -> None:
+    col = MagicMock()
+    col.find_one_and_update = AsyncMock(return_value=None)
+    lock = AsyncMigrationLock(col)
+    with pytest.raises(MigrationLockError):
+        await lock.acquire()
+
+
+@pytest.mark.asyncio
+async def test_async_lock_release() -> None:
+    col = MagicMock()
+    col.update_one = AsyncMock()
+    lock = AsyncMigrationLock(col)
+    await lock.release()
+    col.update_one.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_async_lock_context_manager() -> None:
+    col = MagicMock()
+    col.find_one_and_update = AsyncMock(return_value={"_id": "_mongrator_lock", "locked": True})
+    col.update_one = AsyncMock()
+    lock = AsyncMigrationLock(col)
+    async with lock:
+        pass
+    col.find_one_and_update.assert_called_once()
+    col.update_one.assert_called_once()


### PR DESCRIPTION
💁 These changes add an advisory locking mechanism to prevent concurrent migration runs from corrupting data.

- Adds `SyncMigrationLock` and `AsyncMigrationLock` classes in `state.py` using a document-based lock in the tracking collection
- Lock uses `findOneAndUpdate` with upsert for atomic acquisition
- 10-minute TTL automatically releases stale locks from crashed processes
- Lock is acquired by `up()` and `down()` in both `SyncRunner` and `AsyncRunner`
- Read-only operations (`status`, `validate`, `plan_up`, `plan_down`) do not acquire the lock
- Adds `MigrationLockError` exception raised when the lock cannot be acquired

## Test plan

- [x] Run `uv run pytest tests/unit/` — all 165 tests pass
- [x] Run `uv run pytest tests/integration/` — integration tests pass
- [x] Manual: run two `mongrator up` processes simultaneously — second should fail with lock error