### PR TITLE
feat: Add auto-revert support to drop_index

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,9 +97,11 @@ def down(db):
 | Helper                                                         | Reversible | Description                      |
 |----------------------------------------------------------------|------------|----------------------------------|
 | `ops.create_index(collection, keys, **kwargs)`                 | yes        | Create an index                  |
-| `ops.drop_index(collection, index_name)`                       | no         | Drop an index by name            |
+| `ops.drop_index(collection, index_name, keys=None, **kwargs)`  | keys[^1]   | Drop an index by name            |
 | `ops.rename_field(collection, old, new, filter=None)`          | yes        | Rename a field across documents  |
 | `ops.add_field(collection, field, default_value, filter=None)` | yes        | Add a field with a default value |
+
+[^1]: Only reversible when `keys` is provided. See [writing migrations](docs/writing-migrations.md) for details.
 
 ## CLI reference
 

--- a/docs/writing-migrations.md
+++ b/docs/writing-migrations.md
@@ -22,14 +22,14 @@ def up(db):
 | Helper                                                         | Reversible | Description                          |
 |----------------------------------------------------------------|------------|--------------------------------------|
 | `ops.create_index(collection, keys, **kwargs)`                 | yes        | Create an index                      |
-| `ops.drop_index(collection, index_name, keys=None, **kwargs)`  | yes[^1]    | Drop an index by name                |
+| `ops.drop_index(collection, index_name, keys=None, **kwargs)`  | keys[^1]   | Drop an index by name                |
 | `ops.rename_field(collection, old, new, filter=None)`          | yes        | Rename a field across documents      |
 | `ops.add_field(collection, field, default_value, filter=None)` | yes        | Add a field with a default value     |
 | `ops.drop_field(collection, field, filter=None)`               | no         | Remove a field from documents        |
 | `ops.create_collection(collection, **kwargs)`                  | yes        | Create a collection (reverts by drop)|
 | `ops.drop_collection(collection)`                              | no         | Drop a collection                    |
 
-[^1]: When `keys` (and optional index options) are provided, `drop_index` revert is fully stateless and works with ops-based auto-rollback. Without `keys`, revert depends on the index spec being captured during `apply()` on the same `Operation` instance, and raises `NotImplementedError` if the spec was not captured.
+[^1]: Only reversible when `keys` is provided (e.g. `ops.drop_index("col", "email_1", keys=[("email", 1)], unique=True)`). Without `keys`, `mongrator down` raises `NotImplementedError` — define a `down()` function instead.
 
 See the [ops API reference](api/ops.md) for full details.
 

--- a/docs/writing-migrations.md
+++ b/docs/writing-migrations.md
@@ -22,14 +22,14 @@ def up(db):
 | Helper                                                         | Reversible | Description                          |
 |----------------------------------------------------------------|------------|--------------------------------------|
 | `ops.create_index(collection, keys, **kwargs)`                 | yes        | Create an index                      |
-| `ops.drop_index(collection, index_name)`                       | yes*       | Drop an index by name                |
+| `ops.drop_index(collection, index_name, keys=None, **kwargs)`  | yes[^1]    | Drop an index by name                |
 | `ops.rename_field(collection, old, new, filter=None)`          | yes        | Rename a field across documents      |
 | `ops.add_field(collection, field, default_value, filter=None)` | yes        | Add a field with a default value     |
 | `ops.drop_field(collection, field, filter=None)`               | no         | Remove a field from documents        |
 | `ops.create_collection(collection, **kwargs)`                  | yes        | Create a collection (reverts by drop)|
 | `ops.drop_collection(collection)`                              | no         | Drop a collection                    |
 
-*\* `drop_index` captures the index spec before dropping. Revert recreates the index automatically. If `apply()` was not called first (spec not captured), revert raises `NotImplementedError`.*
+[^1]: When `keys` (and optional index options) are provided, `drop_index` revert is fully stateless and works with ops-based auto-rollback. Without `keys`, revert depends on the index spec being captured during `apply()` on the same `Operation` instance, and raises `NotImplementedError` if the spec was not captured.
 
 See the [ops API reference](api/ops.md) for full details.
 

--- a/docs/writing-migrations.md
+++ b/docs/writing-migrations.md
@@ -22,12 +22,14 @@ def up(db):
 | Helper                                                         | Reversible | Description                          |
 |----------------------------------------------------------------|------------|--------------------------------------|
 | `ops.create_index(collection, keys, **kwargs)`                 | yes        | Create an index                      |
-| `ops.drop_index(collection, index_name)`                       | no         | Drop an index by name                |
+| `ops.drop_index(collection, index_name)`                       | yes*       | Drop an index by name                |
 | `ops.rename_field(collection, old, new, filter=None)`          | yes        | Rename a field across documents      |
 | `ops.add_field(collection, field, default_value, filter=None)` | yes        | Add a field with a default value     |
 | `ops.drop_field(collection, field, filter=None)`               | no         | Remove a field from documents        |
 | `ops.create_collection(collection, **kwargs)`                  | yes        | Create a collection (reverts by drop)|
 | `ops.drop_collection(collection)`                              | no         | Drop a collection                    |
+
+*\* `drop_index` captures the index spec before dropping. Revert recreates the index automatically. If `apply()` was not called first (spec not captured), revert raises `NotImplementedError`.*
 
 See the [ops API reference](api/ops.md) for full details.
 

--- a/src/mongrator/ops.py
+++ b/src/mongrator/ops.py
@@ -82,6 +82,7 @@ def drop_index(
 
     def apply(db: Database) -> None:  # type: ignore[type-arg]
         if keys is None:
+            _captured_spec.clear()
             indexes = db[collection].index_information()
             if index_name in indexes:
                 info = indexes[index_name]

--- a/src/mongrator/ops.py
+++ b/src/mongrator/ops.py
@@ -60,26 +60,46 @@ def create_index(
     )
 
 
-def drop_index(collection: str, index_name: str) -> Operation:
-    """Drop an index by name. Reverts by recreating the index from its captured spec."""
+def drop_index(
+    collection: str,
+    index_name: str,
+    keys: list[tuple[str, int]] | None = None,
+    **kwargs: Any,
+) -> Operation:
+    """Drop an index by name. Reverts by recreating the index.
+
+    When *keys* (and optional index options) are provided, revert is fully
+    stateless — it recreates the index from the supplied spec without needing
+    to have run apply() first.  This is required for the ops-based auto-
+    rollback path where the runner calls ``up(db)`` a second time and then
+    immediately calls ``revert()`` on fresh Operation instances.
+
+    If *keys* is omitted, apply() will attempt to capture the index spec at
+    runtime; however this only works when revert() is called on the **same**
+    Operation instance that ran apply().
+    """
     _captured_spec: dict[str, Any] = {}
 
     def apply(db: Database) -> None:  # type: ignore[type-arg]
-        indexes = db[collection].index_information()
-        if index_name in indexes:
-            info = indexes[index_name]
-            _captured_spec["key"] = info["key"]
-            opts = {k: v for k, v in info.items() if k not in ("key", "v", "ns")}
-            _captured_spec["opts"] = opts
+        if keys is None:
+            indexes = db[collection].index_information()
+            if index_name in indexes:
+                info = indexes[index_name]
+                _captured_spec["key"] = info["key"]
+                opts = {k: v for k, v in info.items() if k not in ("key", "v", "ns")}
+                _captured_spec["opts"] = opts
         db[collection].drop_index(index_name)
 
     def revert(db: Database) -> None:  # type: ignore[type-arg]
-        if not _captured_spec:
+        if keys is not None:
+            db[collection].create_index(keys, **kwargs)
+        elif _captured_spec:
+            db[collection].create_index(_captured_spec["key"], **_captured_spec["opts"])
+        else:
             raise NotImplementedError(
                 f"drop_index({collection!r}, {index_name!r}) cannot be auto-reverted: "
-                "index spec was not captured. Define a down() function to recreate the index."
+                "index spec was not captured. Supply keys= or define a down() function."
             )
-        db[collection].create_index(_captured_spec["key"], **_captured_spec["opts"])
 
     return Operation(
         description=f"drop_index({collection!r}, {index_name!r})",

--- a/src/mongrator/ops.py
+++ b/src/mongrator/ops.py
@@ -79,6 +79,8 @@ def drop_index(
     Operation instance that ran apply().
     """
     _captured_spec: dict[str, Any] = {}
+    # index_name is authoritative; drop any conflicting name from kwargs.
+    kwargs.pop("name", None)
 
     def apply(db: Database) -> None:  # type: ignore[type-arg]
         if keys is None:

--- a/src/mongrator/ops.py
+++ b/src/mongrator/ops.py
@@ -84,13 +84,11 @@ def drop_index(
     Operation instance that ran apply().
     """
     # Normalize dict keys to the list-of-tuples form pymongo expects.
-    _norm_keys: list[tuple[str, int | str]] | None
+    _norm_keys: list[tuple[str, int | str]] | None = None
     if isinstance(keys, dict):
-        _norm_keys = list(keys.items())
+        _norm_keys = [(k, v) for k, v in keys.items()]  # ty: ignore[invalid-assignment]
     elif keys is not None:
         _norm_keys = list(keys)
-    else:
-        _norm_keys = None
 
     _captured_spec: dict[str, Any] = {}
     # index_name is authoritative; drop any conflicting name from kwargs.

--- a/src/mongrator/ops.py
+++ b/src/mongrator/ops.py
@@ -16,6 +16,7 @@ Usage in a migration file::
         ]
 """
 
+from collections.abc import Sequence
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -39,7 +40,7 @@ class Operation:
 
 def create_index(
     collection: str,
-    keys: dict[str, int],
+    keys: dict[str, int | str],
     **kwargs: Any,
 ) -> Operation:
     """Create an index. Reverts by dropping the index."""
@@ -63,7 +64,7 @@ def create_index(
 def drop_index(
     collection: str,
     index_name: str,
-    keys: list[tuple[str, int]] | None = None,
+    keys: dict[str, int | str] | Sequence[tuple[str, int | str]] | None = None,
     **kwargs: Any,
 ) -> Operation:
     """Drop an index by name. Reverts by recreating the index.
@@ -74,16 +75,29 @@ def drop_index(
     rollback path where the runner calls ``up(db)`` a second time and then
     immediately calls ``revert()`` on fresh Operation instances.
 
+    *keys* accepts the same ``dict`` form used by ``create_index`` (e.g.
+    ``{"email": 1}``) or a ``list[tuple]`` matching pymongo's format (e.g.
+    ``[("email", 1)]``).  A dict is normalized to a list of tuples internally.
+
     If *keys* is omitted, apply() will attempt to capture the index spec at
     runtime; however this only works when revert() is called on the **same**
     Operation instance that ran apply().
     """
+    # Normalize dict keys to the list-of-tuples form pymongo expects.
+    _norm_keys: list[tuple[str, int | str]] | None
+    if isinstance(keys, dict):
+        _norm_keys = list(keys.items())
+    elif keys is not None:
+        _norm_keys = list(keys)
+    else:
+        _norm_keys = None
+
     _captured_spec: dict[str, Any] = {}
     # index_name is authoritative; drop any conflicting name from kwargs.
     kwargs.pop("name", None)
 
     def apply(db: Database) -> None:  # type: ignore[type-arg]
-        if keys is None:
+        if _norm_keys is None:
             _captured_spec.clear()
             indexes = db[collection].index_information()
             if index_name in indexes:
@@ -94,8 +108,8 @@ def drop_index(
         db[collection].drop_index(index_name)
 
     def revert(db: Database) -> None:  # type: ignore[type-arg]
-        if keys is not None:
-            db[collection].create_index(keys, name=index_name, **kwargs)
+        if _norm_keys is not None:
+            db[collection].create_index(_norm_keys, name=index_name, **kwargs)
         elif _captured_spec:
             _captured_spec["opts"]["name"] = index_name
             db[collection].create_index(_captured_spec["key"], **_captured_spec["opts"])

--- a/src/mongrator/ops.py
+++ b/src/mongrator/ops.py
@@ -61,16 +61,25 @@ def create_index(
 
 
 def drop_index(collection: str, index_name: str) -> Operation:
-    """Drop an index by name. Not auto-reversible (index spec is unknown)."""
+    """Drop an index by name. Reverts by recreating the index from its captured spec."""
+    _captured_spec: dict[str, Any] = {}
 
     def apply(db: Database) -> None:  # type: ignore[type-arg]
+        indexes = db[collection].index_information()
+        if index_name in indexes:
+            info = indexes[index_name]
+            _captured_spec["key"] = info["key"]
+            opts = {k: v for k, v in info.items() if k not in ("key", "v", "ns")}
+            _captured_spec["opts"] = opts
         db[collection].drop_index(index_name)
 
     def revert(db: Database) -> None:  # type: ignore[type-arg]
-        raise NotImplementedError(
-            f"drop_index({collection!r}, {index_name!r}) cannot be auto-reverted. "
-            "Define a down() function to recreate the index."
-        )
+        if not _captured_spec:
+            raise NotImplementedError(
+                f"drop_index({collection!r}, {index_name!r}) cannot be auto-reverted: "
+                "index spec was not captured. Define a down() function to recreate the index."
+            )
+        db[collection].create_index(_captured_spec["key"], **_captured_spec["opts"])
 
     return Operation(
         description=f"drop_index({collection!r}, {index_name!r})",

--- a/src/mongrator/ops.py
+++ b/src/mongrator/ops.py
@@ -92,8 +92,9 @@ def drop_index(
 
     def revert(db: Database) -> None:  # type: ignore[type-arg]
         if keys is not None:
-            db[collection].create_index(keys, **kwargs)
+            db[collection].create_index(keys, name=index_name, **kwargs)
         elif _captured_spec:
+            _captured_spec["opts"]["name"] = index_name
             db[collection].create_index(_captured_spec["key"], **_captured_spec["opts"])
         else:
             raise NotImplementedError(

--- a/tests/integration/test_async_runner.py
+++ b/tests/integration/test_async_runner.py
@@ -164,6 +164,39 @@ async def test_down_ops_auto_rollback_drops_index(runner: AsyncRunner, migration
     assert "email_1" not in index_names
 
 
+async def test_down_drop_index_ops_auto_rollback_recreates_index(
+    runner: AsyncRunner,
+    migrations_dir: Path,
+    db: Database,
+) -> None:
+    # First migration creates the index
+    write_migration(
+        migrations_dir,
+        "001_create_idx.py",
+        "from mongrator import ops\ndef up(db):\n    return [ops.create_index('col', {'email': 1}, unique=True)]\n",
+    )
+    # Second migration drops the index with explicit keys for stateless revert
+    write_migration(
+        migrations_dir,
+        "002_drop_idx.py",
+        "from mongrator import ops\n"
+        "def up(db):\n"
+        "    return [ops.drop_index('col', 'email_1', keys=[('email', 1)], unique=True)]\n",
+    )
+    await runner.up()
+    # Index should be gone after both migrations applied
+    index_names = [idx["name"] for idx in db["col"].list_indexes()]  # type: ignore[index]
+    assert "email_1" not in index_names
+
+    # Roll back only the drop_index migration — index should be recreated
+    await runner.down(steps=1)
+    index_names = [idx["name"] for idx in db["col"].list_indexes()]  # type: ignore[index]
+    assert "email_1" in index_names
+    # Verify the recreated index preserved its unique option
+    index_info = db["col"].index_information()  # type: ignore[index]
+    assert index_info["email_1"]["unique"] is True
+
+
 async def test_down_no_down_method_raises(runner: AsyncRunner, migrations_dir: Path) -> None:
     write_migration(migrations_dir, "001_a.py", "def up(db): pass\n")
     await runner.up()

--- a/tests/integration/test_sync_runner.py
+++ b/tests/integration/test_sync_runner.py
@@ -164,6 +164,39 @@ def test_down_ops_auto_rollback_drops_index(runner: SyncRunner, migrations_dir: 
     assert "email_1" not in index_names
 
 
+def test_down_drop_index_ops_auto_rollback_recreates_index(
+    runner: SyncRunner,
+    migrations_dir: Path,
+    db: Database,
+) -> None:
+    # First migration creates the index
+    write_migration(
+        migrations_dir,
+        "001_create_idx.py",
+        "from mongrator import ops\ndef up(db):\n    return [ops.create_index('col', {'email': 1}, unique=True)]\n",
+    )
+    # Second migration drops the index with explicit keys for stateless revert
+    write_migration(
+        migrations_dir,
+        "002_drop_idx.py",
+        "from mongrator import ops\n"
+        "def up(db):\n"
+        "    return [ops.drop_index('col', 'email_1', keys=[('email', 1)], unique=True)]\n",
+    )
+    runner.up()
+    # Index should be gone after both migrations applied
+    index_names = [idx["name"] for idx in db["col"].list_indexes()]  # type: ignore[index]
+    assert "email_1" not in index_names
+
+    # Roll back only the drop_index migration — index should be recreated
+    runner.down(steps=1)
+    index_names = [idx["name"] for idx in db["col"].list_indexes()]  # type: ignore[index]
+    assert "email_1" in index_names
+    # Verify the recreated index preserved its unique option
+    index_info = db["col"].index_information()  # type: ignore[index]
+    assert index_info["email_1"]["unique"] is True
+
+
 def test_down_no_down_method_raises(runner: SyncRunner, migrations_dir: Path) -> None:
     write_migration(migrations_dir, "001_a.py", "def up(db): pass\n")
     runner.up()

--- a/tests/unit/test_ops.py
+++ b/tests/unit/test_ops.py
@@ -166,6 +166,29 @@ def test_drop_index_stateless_revert_name_in_kwargs_no_conflict() -> None:
     )
 
 
+def test_drop_index_stateless_revert_dict_keys() -> None:
+    """keys passed as a dict is normalized to list-of-tuples for create_index."""
+    db = _db()
+    op = drop_index("users", "email_1", keys={"email": 1}, unique=True)
+    op.revert(db)
+    db["users"].create_index.assert_called_once_with(
+        [("email", 1)],
+        name="email_1",
+        unique=True,
+    )
+
+
+def test_drop_index_stateless_revert_string_direction() -> None:
+    """Non-int direction values (e.g. 'text', '2dsphere') are accepted."""
+    db = _db()
+    op = drop_index("posts", "content_text", keys=[("content", "text")])
+    op.revert(db)
+    db["posts"].create_index.assert_called_once_with(
+        [("content", "text")],
+        name="content_text",
+    )
+
+
 def test_drop_index_stateless_apply_skips_capture() -> None:
     """When keys are supplied, apply() drops the index without querying index_information."""
     db = _db()

--- a/tests/unit/test_ops.py
+++ b/tests/unit/test_ops.py
@@ -154,6 +154,18 @@ def test_drop_index_stateless_revert_with_keys() -> None:
     db["users"].create_index.assert_called_once_with([("email", 1)], name="email_1", unique=True)
 
 
+def test_drop_index_stateless_revert_name_in_kwargs_no_conflict() -> None:
+    """Passing name= in kwargs does not cause a duplicate keyword argument error."""
+    db = _db()
+    op = drop_index("users", "my_idx", keys=[("email", 1)], name="ignored", unique=True)
+    op.revert(db)
+    db["users"].create_index.assert_called_once_with(
+        [("email", 1)],
+        name="my_idx",
+        unique=True,
+    )
+
+
 def test_drop_index_stateless_apply_skips_capture() -> None:
     """When keys are supplied, apply() drops the index without querying index_information."""
     db = _db()

--- a/tests/unit/test_ops.py
+++ b/tests/unit/test_ops.py
@@ -119,7 +119,7 @@ def test_drop_index_revert_recreates_index() -> None:
     op.apply(db)
     db.reset_mock()
     op.revert(db)
-    db["users"].create_index.assert_called_once_with([("email", 1)], unique=True)
+    db["users"].create_index.assert_called_once_with([("email", 1)], unique=True, name="email_1")
 
 
 def test_drop_index_revert_raises_without_capture() -> None:
@@ -134,7 +134,7 @@ def test_drop_index_stateless_revert_with_keys() -> None:
     db = _db()
     op = drop_index("users", "email_1", keys=[("email", 1)], unique=True)
     op.revert(db)
-    db["users"].create_index.assert_called_once_with([("email", 1)], unique=True)
+    db["users"].create_index.assert_called_once_with([("email", 1)], name="email_1", unique=True)
 
 
 def test_drop_index_stateless_apply_skips_capture() -> None:
@@ -155,7 +155,7 @@ def test_drop_index_stateless_revert_without_apply() -> None:
     # Second call — runner calls up() again then reverts fresh instances
     op2 = drop_index("users", "email_1", keys=[("email", 1)], unique=True)
     op2.revert(db)
-    db["users"].create_index.assert_called_once_with([("email", 1)], unique=True)
+    db["users"].create_index.assert_called_once_with([("email", 1)], name="email_1", unique=True)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_ops.py
+++ b/tests/unit/test_ops.py
@@ -92,14 +92,37 @@ def test_drop_index_description() -> None:
     assert "email_1" in op.description
 
 
-def test_drop_index_apply() -> None:
+def test_drop_index_apply_captures_spec() -> None:
     db = _db()
+    db["users"].index_information.return_value = {
+        "email_1": {"key": [("email", 1)], "unique": True, "v": 2},
+    }
     op = drop_index("users", "email_1")
     op.apply(db)
     db["users"].drop_index.assert_called_once_with("email_1")
 
 
-def test_drop_index_revert_raises() -> None:
+def test_drop_index_apply_missing_index() -> None:
+    db = _db()
+    db["users"].index_information.return_value = {}
+    op = drop_index("users", "email_1")
+    op.apply(db)
+    db["users"].drop_index.assert_called_once_with("email_1")
+
+
+def test_drop_index_revert_recreates_index() -> None:
+    db = _db()
+    db["users"].index_information.return_value = {
+        "email_1": {"key": [("email", 1)], "unique": True, "v": 2},
+    }
+    op = drop_index("users", "email_1")
+    op.apply(db)
+    db.reset_mock()
+    op.revert(db)
+    db["users"].create_index.assert_called_once_with([("email", 1)], unique=True)
+
+
+def test_drop_index_revert_raises_without_capture() -> None:
     db = _db()
     op = drop_index("users", "email_1")
     with pytest.raises(NotImplementedError):

--- a/tests/unit/test_ops.py
+++ b/tests/unit/test_ops.py
@@ -129,6 +129,23 @@ def test_drop_index_revert_raises_without_capture() -> None:
         op.revert(db)
 
 
+def test_drop_index_double_apply_clears_stale_spec() -> None:
+    """A second apply() where the index is gone must not leave stale captured state."""
+    db = _db()
+    # First apply captures the spec
+    db["users"].index_information.return_value = {
+        "email_1": {"key": [("email", 1)], "unique": True, "v": 2},
+    }
+    op = drop_index("users", "email_1")
+    op.apply(db)
+    # Second apply — index no longer exists
+    db["users"].index_information.return_value = {}
+    op.apply(db)
+    # revert should fail because captured spec was cleared
+    with pytest.raises(NotImplementedError):
+        op.revert(db)
+
+
 def test_drop_index_stateless_revert_with_keys() -> None:
     """When keys are supplied, revert recreates the index without needing apply()."""
     db = _db()

--- a/tests/unit/test_ops.py
+++ b/tests/unit/test_ops.py
@@ -129,6 +129,35 @@ def test_drop_index_revert_raises_without_capture() -> None:
         op.revert(db)
 
 
+def test_drop_index_stateless_revert_with_keys() -> None:
+    """When keys are supplied, revert recreates the index without needing apply()."""
+    db = _db()
+    op = drop_index("users", "email_1", keys=[("email", 1)], unique=True)
+    op.revert(db)
+    db["users"].create_index.assert_called_once_with([("email", 1)], unique=True)
+
+
+def test_drop_index_stateless_apply_skips_capture() -> None:
+    """When keys are supplied, apply() drops the index without querying index_information."""
+    db = _db()
+    op = drop_index("users", "email_1", keys=[("email", 1)])
+    op.apply(db)
+    db["users"].drop_index.assert_called_once_with("email_1")
+    db["users"].index_information.assert_not_called()
+
+
+def test_drop_index_stateless_revert_without_apply() -> None:
+    """Simulates the runner's auto-rollback: fresh instance, no apply(), revert works."""
+    db = _db()
+    # First call — the "up" run
+    op1 = drop_index("users", "email_1", keys=[("email", 1)], unique=True)
+    op1.apply(db)
+    # Second call — runner calls up() again then reverts fresh instances
+    op2 = drop_index("users", "email_1", keys=[("email", 1)], unique=True)
+    op2.revert(db)
+    db["users"].create_index.assert_called_once_with([("email", 1)], unique=True)
+
+
 # ---------------------------------------------------------------------------
 # rename_field
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -2,6 +2,7 @@
 
 import types
 from pathlib import Path
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -9,7 +10,7 @@ import pytest
 from mongrator.config import MigratorConfig
 from mongrator.exceptions import MigrationLockError, NoDownMethodError
 from mongrator.migration import MigrationFile
-from mongrator.ops import create_index
+from mongrator.ops import create_index, drop_index
 from mongrator.runner import AsyncRunner, SyncRunner
 from mongrator.state import make_record
 
@@ -22,9 +23,17 @@ def _config(tmp_path: Path) -> MigratorConfig:
     return MigratorConfig(uri="mongodb://localhost:27017", database="testdb", migrations_dir=tmp_path)
 
 
-def _migration(migration_id: str, *, has_down: bool = False, ops_based: bool = False) -> MigrationFile:
+def _migration(
+    migration_id: str,
+    *,
+    has_down: bool = False,
+    ops_based: bool = False,
+    ops_fn: Any = None,
+) -> MigrationFile:
     mod = types.ModuleType(f"_test_{migration_id}")
-    if ops_based:
+    if ops_fn is not None:
+        setattr(mod, "up", ops_fn)
+    elif ops_based:
         index_op = create_index("col", {"field": 1})
         setattr(mod, "up", lambda db: [index_op])
     else:
@@ -176,6 +185,27 @@ def test_sync_down_ops_based_auto_rollback(tmp_path: Path) -> None:
     assert rolled_back == ["001_a"]
 
 
+def test_sync_down_drop_index_ops_auto_rollback(tmp_path: Path) -> None:
+    """SyncRunner.down() auto-reverts drop_index on fresh Operation instances."""
+    runner, db, store = _sync_runner(tmp_path)
+
+    def up_fn(db: Any) -> list:
+        return [drop_index("col", "email_1", keys=[("email", 1)], unique=True)]
+
+    migrations = [_migration("001_a", ops_fn=up_fn)]
+    store.get_applied.return_value = {"001_a"}
+
+    with patch("mongrator.runner.loader.load", return_value=migrations):
+        rolled_back = runner.down()
+
+    assert rolled_back == ["001_a"]
+    db["col"].create_index.assert_called_once_with(
+        [("email", 1)],
+        name="email_1",
+        unique=True,
+    )
+
+
 def test_sync_down_records_direction_down(tmp_path: Path) -> None:
     runner, db, store = _sync_runner(tmp_path)
     migrations = [_migration("001_a", has_down=True)]
@@ -299,6 +329,30 @@ async def test_async_down_rolls_back(tmp_path: Path) -> None:
         rolled_back = await runner.down(steps=1)
 
     assert rolled_back == ["002_b"]
+
+
+@pytest.mark.asyncio
+async def test_async_down_drop_index_ops_auto_rollback(tmp_path: Path) -> None:
+    """AsyncRunner.down() auto-reverts drop_index on fresh Operation instances."""
+    runner, db, store = _async_runner(tmp_path)
+    # AsyncRunner._db is set from a real MongoClient in __init__; override with mock.
+    runner._db = db
+
+    def up_fn(db: Any) -> list:
+        return [drop_index("col", "email_1", keys=[("email", 1)], unique=True)]
+
+    migrations = [_migration("001_a", ops_fn=up_fn)]
+    store.get_applied.return_value = {"001_a"}
+
+    with patch("mongrator.runner.loader.load", return_value=migrations):
+        rolled_back = await runner.down()
+
+    assert rolled_back == ["001_a"]
+    db["col"].create_index.assert_called_once_with(
+        [("email", 1)],
+        name="email_1",
+        unique=True,
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
💁 These changes make `ops.drop_index()` auto-reversible by accepting an explicit `keys` parameter that enables stateless revert — no prior `apply()` call needed.

- Accept `keys` as `dict[str, int | str]` or `Sequence[tuple[str, int | str]]` (consistent with `create_index`), normalized to list-of-tuples internally
- When `keys` is provided, `revert()` recreates the index purely from the supplied spec — works with the runner's auto-rollback path where `up(db)` is re-called on fresh `Operation` instances
- Without `keys`, falls back to runtime capture via `apply()` (same-instance only) or raises `NotImplementedError`
- Preserve `name=index_name` on recreated indexes so revert is a true inverse
- Clear `_captured_spec` at the start of `apply()` to prevent stale state on repeated calls
- Prevent `TypeError` when callers pass `name=` in kwargs (index_name is authoritative)
- Update README and docs to reflect the new signature and reversibility conditions

## Test plan

- [x] Run `uv run pytest tests/unit/test_ops.py` — 41 tests pass (stateless revert, dict keys, string directions, duplicate name, stale spec)
- [x] Run `uv run pytest tests/unit/test_runner.py` — SyncRunner and AsyncRunner `down()` with `drop_index` ops auto-rollback
- [x] Run `uv run pytest tests/integration/` — end-to-end up+down cycle against real MongoDB confirms index recreation with correct name and options
- [x] `uvx ruff check` and `uvx ruff format --check` pass
- [x] `uvx ty check` passes
- [x] `markdownlint` passes on all docs