### PR TITLE
refactor(runner): remove unused _resolve_rollback function

### DIFF
--- a/src/mongrator/runner.py
+++ b/src/mongrator/runner.py
@@ -40,15 +40,6 @@ class AsyncMigrationRunner(Protocol):
     async def validate(self) -> list[ChecksumMismatchError]: ...
 
 
-def _resolve_rollback(migration: MigrationFile) -> None:
-    """Raise NoDownMethodError if the migration cannot be rolled back."""
-    if migration.has_down():
-        return
-    # Check if up() returns a list of Operations with revert support
-    # (We cannot call up() here; this is checked at rollback time instead.)
-    raise NoDownMethodError(migration.id)
-
-
 def _run_up_migration(migration: MigrationFile, db: Any) -> None:
     """Execute the up() callable, calling Operation.apply() for each op if needed."""
     up_fn = migration.up


### PR DESCRIPTION
💁 These changes remove the dead `_resolve_rollback()` function from `runner.py`. It was defined but never called anywhere in the codebase — the actual rollback validation happens inline in `_run_down_migration()` and `_run_down_ops()`.