### PR TITLE
feat(ops): add reversibility check for operations

### DIFF
--- a/src/mongrator/ops.py
+++ b/src/mongrator/ops.py
@@ -25,7 +25,12 @@ from pymongo.database import Database
 
 @dataclass
 class Operation:
-    """An atomic, reversible database operation."""
+    """An atomic database operation, optionally auto-reversible.
+
+    Check ``is_reversible`` before relying on ``revert()``. Operations whose
+    ``is_reversible`` is ``False`` will raise ``NotImplementedError`` from
+    ``revert()`` — a ``down()`` function is required to roll them back.
+    """
 
     description: str
     _apply: Any = field(repr=False)

--- a/src/mongrator/ops.py
+++ b/src/mongrator/ops.py
@@ -30,6 +30,18 @@ class Operation:
     description: str
     _apply: Any = field(repr=False)
     _revert: Any = field(repr=False)
+    _is_reversible: bool = field(default=True, repr=False)
+
+    @property
+    def is_reversible(self) -> bool:
+        """Whether ``revert()`` is expected to succeed.
+
+        Returns ``False`` for operations that will raise ``NotImplementedError``
+        on revert (e.g. ``drop_index`` without ``keys``, ``drop_field``,
+        ``drop_collection``).  Callers can inspect this at plan/load time to
+        warn about migrations that are not safely rollback-able.
+        """
+        return self._is_reversible
 
     def apply(self, db: Database) -> None:  # type: ignore[type-arg]
         self._apply(db)
@@ -121,6 +133,7 @@ def drop_index(
         description=f"drop_index({collection!r}, {index_name!r})",
         _apply=apply,
         _revert=revert,
+        _is_reversible=_norm_keys is not None,
     )
 
 
@@ -199,6 +212,7 @@ def drop_field(
         description=f"drop_field({collection!r}, {field_name!r})",
         _apply=apply,
         _revert=revert,
+        _is_reversible=False,
     )
 
 
@@ -237,4 +251,5 @@ def drop_collection(collection: str) -> Operation:
         description=f"drop_collection({collection!r})",
         _apply=apply,
         _revert=revert,
+        _is_reversible=False,
     )

--- a/src/mongrator/ops.py
+++ b/src/mongrator/ops.py
@@ -34,12 +34,15 @@ class Operation:
 
     @property
     def is_reversible(self) -> bool:
-        """Whether ``revert()`` is expected to succeed.
+        """Whether ``revert()`` can succeed on a fresh Operation instance.
 
-        Returns ``False`` for operations that will raise ``NotImplementedError``
-        on revert (e.g. ``drop_index`` without ``keys``, ``drop_field``,
-        ``drop_collection``).  Callers can inspect this at plan/load time to
-        warn about migrations that are not safely rollback-able.
+        The runner's auto-rollback path calls ``up(db)`` a second time to obtain
+        new Operation instances and then calls ``revert()`` on them.  Because
+        these are fresh instances, any state captured during ``apply()`` is not
+        available.  This property returns ``False`` when revert requires such
+        runtime state (e.g. ``drop_index`` without explicit ``keys``) or when
+        the operation is inherently destructive (``drop_field``,
+        ``drop_collection``).
         """
         return self._is_reversible
 

--- a/src/mongrator/runner.py
+++ b/src/mongrator/runner.py
@@ -56,8 +56,7 @@ def _run_up_migration(migration: MigrationFile, db: Any) -> None:
                 if not op.is_reversible:
                     print(
                         f"warning: operation {op.description} is not auto-reversible; "
-                        "rollback will fail without a down() function. "
-                        "Supply keys= to the operation or define a down() function.",
+                        "rollback will fail without a down() function.",
                         file=sys.stderr,
                     )
         for op in ops:

--- a/src/mongrator/runner.py
+++ b/src/mongrator/runner.py
@@ -52,13 +52,15 @@ def _run_up_migration(migration: MigrationFile, db: Any) -> None:
         # Raw pymongo migrations return None.
         ops = cast(list[Operation], result)
         if not migration.has_down():
-            for op in ops:
-                if not op.is_reversible:
-                    print(
-                        f"warning: operation {op.description} is not auto-reversible; "
-                        "rollback will fail without a down() function.",
-                        file=sys.stderr,
-                    )
+            irreversible = [op.description for op in ops if not op.is_reversible]
+            if irreversible:
+                op_list = ", ".join(irreversible)
+                print(
+                    f"warning: migration {migration.id} ({migration.path}) has "
+                    f"{len(irreversible)} non-auto-reversible operation(s): {op_list}; "
+                    "rollback will fail without a down() function.",
+                    file=sys.stderr,
+                )
         for op in ops:
             op.apply(db)  # type: ignore[arg-type]
 

--- a/src/mongrator/runner.py
+++ b/src/mongrator/runner.py
@@ -6,6 +6,7 @@ AsyncRunner wraps a pymongo AsyncMongoClient.
 Both share the same non-IO logic via loader and planner.
 """
 
+import sys
 import time
 from typing import Any, Protocol, cast, runtime_checkable
 
@@ -49,7 +50,14 @@ def _run_up_migration(migration: MigrationFile, db: Any) -> None:
     if isinstance(result, list) and all(isinstance(op, Operation) for op in result):
         # ops-based migration: up() returns ops, runner applies them.
         # Raw pymongo migrations return None.
-        for op in cast(list[Operation], result):
+        ops = cast(list[Operation], result)
+        for op in ops:
+            if not op.is_reversible:
+                print(
+                    f"warning: operation {op.description} is not reversible; "
+                    "auto-rollback will fail. Supply keys= or define a down() function.",
+                    file=sys.stderr,
+                )
             op.apply(db)  # type: ignore[arg-type]
 
 

--- a/src/mongrator/runner.py
+++ b/src/mongrator/runner.py
@@ -51,13 +51,16 @@ def _run_up_migration(migration: MigrationFile, db: Any) -> None:
         # ops-based migration: up() returns ops, runner applies them.
         # Raw pymongo migrations return None.
         ops = cast(list[Operation], result)
+        if not migration.has_down():
+            for op in ops:
+                if not op.is_reversible:
+                    print(
+                        f"warning: operation {op.description} is not auto-reversible; "
+                        "rollback will fail without a down() function. "
+                        "Supply keys= to the operation or define a down() function.",
+                        file=sys.stderr,
+                    )
         for op in ops:
-            if not op.is_reversible:
-                print(
-                    f"warning: operation {op.description} is not reversible; "
-                    "auto-rollback will fail. Supply keys= or define a down() function.",
-                    file=sys.stderr,
-                )
             op.apply(db)  # type: ignore[arg-type]
 
 

--- a/tests/unit/test_ops.py
+++ b/tests/unit/test_ops.py
@@ -41,6 +41,53 @@ def test_operation_revert_delegates() -> None:
     assert called_with == [sentinel]
 
 
+def test_operation_is_reversible_default() -> None:
+    op = Operation("desc", _apply=lambda db: None, _revert=lambda db: None)
+    assert op.is_reversible is True
+
+
+def test_operation_is_reversible_false() -> None:
+    op = Operation("desc", _apply=lambda db: None, _revert=lambda db: None, _is_reversible=False)
+    assert op.is_reversible is False
+
+
+# ---------------------------------------------------------------------------
+# is_reversible per helper
+# ---------------------------------------------------------------------------
+
+
+def test_create_index_is_reversible() -> None:
+    assert create_index("users", {"email": 1}).is_reversible is True
+
+
+def test_drop_index_with_keys_is_reversible() -> None:
+    assert drop_index("users", "email_1", keys=[("email", 1)]).is_reversible is True
+
+
+def test_drop_index_without_keys_is_not_reversible() -> None:
+    assert drop_index("users", "email_1").is_reversible is False
+
+
+def test_rename_field_is_reversible() -> None:
+    assert rename_field("users", "name", "full_name").is_reversible is True
+
+
+def test_add_field_is_reversible() -> None:
+    assert add_field("users", "verified", False).is_reversible is True
+
+
+def test_drop_field_is_not_reversible() -> None:
+    assert drop_field("users", "legacy_flag").is_reversible is False
+
+
+def test_create_collection_is_reversible() -> None:
+    assert create_collection("audit_log").is_reversible is True
+
+
+def test_drop_collection_is_not_reversible() -> None:
+    assert drop_collection("old_logs").is_reversible is False
+
+
 # ---------------------------------------------------------------------------
 # create_index
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -120,6 +120,41 @@ def test_sync_up_with_target(tmp_path: Path) -> None:
     assert applied == ["001_a", "002_b"]
 
 
+def test_sync_up_warns_irreversible_ops(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    runner, db, store = _sync_runner(tmp_path)
+
+    def up_fn(db: Any) -> list:
+        return [drop_index("col", "email_1")]
+
+    migrations = [_migration("001_a", ops_fn=up_fn)]
+    store.get_applied.return_value = set()
+    db["col"].index_information.return_value = {}
+
+    with patch("mongrator.runner.loader.load", return_value=migrations):
+        runner.up()
+
+    captured = capsys.readouterr()
+    assert "warning:" in captured.err
+    assert "not reversible" in captured.err
+    assert "drop_index" in captured.err
+
+
+def test_sync_up_no_warning_for_reversible_ops(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    runner, db, store = _sync_runner(tmp_path)
+
+    def up_fn(db: Any) -> list:
+        return [drop_index("col", "email_1", keys=[("email", 1)])]
+
+    migrations = [_migration("001_a", ops_fn=up_fn)]
+    store.get_applied.return_value = set()
+
+    with patch("mongrator.runner.loader.load", return_value=migrations):
+        runner.up()
+
+    captured = capsys.readouterr()
+    assert "warning:" not in captured.err
+
+
 def test_sync_up_records_direction_up(tmp_path: Path) -> None:
     runner, db, store = _sync_runner(tmp_path)
     migrations = [_migration("001_a")]

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -135,8 +135,25 @@ def test_sync_up_warns_irreversible_ops(tmp_path: Path, capsys: pytest.CaptureFi
 
     captured = capsys.readouterr()
     assert "warning:" in captured.err
-    assert "not reversible" in captured.err
+    assert "not auto-reversible" in captured.err
     assert "drop_index" in captured.err
+
+
+def test_sync_up_no_warning_when_down_defined(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    runner, db, store = _sync_runner(tmp_path)
+
+    def up_fn(db: Any) -> list:
+        return [drop_index("col", "email_1")]
+
+    migrations = [_migration("001_a", ops_fn=up_fn, has_down=True)]
+    store.get_applied.return_value = set()
+    db["col"].index_information.return_value = {}
+
+    with patch("mongrator.runner.loader.load", return_value=migrations):
+        runner.up()
+
+    captured = capsys.readouterr()
+    assert "warning:" not in captured.err
 
 
 def test_sync_up_no_warning_for_reversible_ops(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -135,7 +135,7 @@ def test_sync_up_warns_irreversible_ops(tmp_path: Path, capsys: pytest.CaptureFi
 
     captured = capsys.readouterr()
     assert "warning:" in captured.err
-    assert "not auto-reversible" in captured.err
+    assert "non-auto-reversible" in captured.err
     assert "drop_index" in captured.err
 
 


### PR DESCRIPTION
💁 These changes add an `is_reversible` property to the `Operation` dataclass. When `drop_index` is used without `keys=`, the property returns `False`, and the runner emits a warning to stderr during `up()` so users know before a rollback attempt that auto-revert won't work.