### PR TITLE
feat(cli): add distinct exit code for no-op migrations

### DIFF
--- a/src/mongrator/cli.py
+++ b/src/mongrator/cli.py
@@ -9,9 +9,11 @@ Subcommands:
     validate — verify checksums of applied migrations
 
 Exit codes:
-    0 — changes were applied / rolled back successfully
-    1 — an error occurred
-    2 — already up-to-date (no migrations to apply or roll back)
+    0   — success (changes applied / rolled back, or read-only command succeeded)
+    1   — runtime error (MigratorError)
+    2   — CLI usage error (invalid arguments, missing subcommand)
+    4   — already up-to-date (no migrations to apply or roll back)
+    130 — interrupted (KeyboardInterrupt / Ctrl-C)
 """
 
 import argparse
@@ -29,7 +31,8 @@ from .exceptions import MigratorError
 from .planner import MigrationPlan
 
 #: Exit code returned when there are no migrations to apply or roll back.
-EXIT_NOTHING_TO_DO = 2
+#: Deliberately avoids ``2``, which argparse uses for CLI usage errors.
+EXIT_NOTHING_TO_DO = 4
 
 
 def _positive_int(value: str) -> int:

--- a/src/mongrator/cli.py
+++ b/src/mongrator/cli.py
@@ -7,6 +7,11 @@ Subcommands:
     up       — apply pending migrations
     down     — roll back applied migrations
     validate — verify checksums of applied migrations
+
+Exit codes:
+    0 — changes were applied / rolled back successfully
+    1 — an error occurred
+    2 — already up-to-date (no migrations to apply or roll back)
 """
 
 import argparse
@@ -22,6 +27,9 @@ from pymongo import AsyncMongoClient
 from .config import MigratorConfig
 from .exceptions import MigratorError
 from .planner import MigrationPlan
+
+#: Exit code returned when there are no migrations to apply or roll back.
+EXIT_NOTHING_TO_DO = 2
 
 
 def _positive_int(value: str) -> int:
@@ -183,14 +191,14 @@ def _cmd_up(args: argparse.Namespace) -> int:
         if args.dry_run:
             plan = runner.plan_up(target=args.target)
             _print_dry_run(plan, direction="up")
-            return 0
+            return EXIT_NOTHING_TO_DO if not plan.to_apply else 0
         applied = runner.up(target=args.target)
     if applied:
         for mid in applied:
             print(f"  applied  {mid}")
-    else:
-        print("Nothing to apply.")
-    return 0
+        return 0
+    print("Nothing to apply.")
+    return EXIT_NOTHING_TO_DO
 
 
 async def _async_up(config: MigratorConfig, target: str | None, *, dry_run: bool = False) -> int:
@@ -202,14 +210,14 @@ async def _async_up(config: MigratorConfig, target: str | None, *, dry_run: bool
             if dry_run:
                 plan = await runner.plan_up(target=target)
                 _print_dry_run(plan, direction="up")
-                return 0
+                return EXIT_NOTHING_TO_DO if not plan.to_apply else 0
             applied = await runner.up(target=target)
     if applied:
         for mid in applied:
             print(f"  applied  {mid}")
-    else:
-        print("Nothing to apply.")
-    return 0
+        return 0
+    print("Nothing to apply.")
+    return EXIT_NOTHING_TO_DO
 
 
 def _cmd_down(args: argparse.Namespace) -> int:
@@ -223,14 +231,14 @@ def _cmd_down(args: argparse.Namespace) -> int:
         if args.dry_run:
             plan = runner.plan_down(steps=args.steps)
             _print_dry_run(plan, direction="down")
-            return 0
+            return EXIT_NOTHING_TO_DO if not plan.to_apply else 0
         rolled_back = runner.down(steps=args.steps)
     if rolled_back:
         for mid in rolled_back:
             print(f"  rolled back  {mid}")
-    else:
-        print("Nothing to roll back.")
-    return 0
+        return 0
+    print("Nothing to roll back.")
+    return EXIT_NOTHING_TO_DO
 
 
 async def _async_down(config: MigratorConfig, steps: int, *, dry_run: bool = False) -> int:
@@ -242,14 +250,14 @@ async def _async_down(config: MigratorConfig, steps: int, *, dry_run: bool = Fal
             if dry_run:
                 plan = await runner.plan_down(steps=steps)
                 _print_dry_run(plan, direction="down")
-                return 0
+                return EXIT_NOTHING_TO_DO if not plan.to_apply else 0
             rolled_back = await runner.down(steps=steps)
     if rolled_back:
         for mid in rolled_back:
             print(f"  rolled back  {mid}")
-    else:
-        print("Nothing to roll back.")
-    return 0
+        return 0
+    print("Nothing to roll back.")
+    return EXIT_NOTHING_TO_DO
 
 
 def _cmd_validate(args: argparse.Namespace) -> int:

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -319,6 +319,38 @@ def test_cmd_up_nothing_to_apply(capsys: pytest.CaptureFixture[str]) -> None:
     assert "Nothing to apply" in capsys.readouterr().out
 
 
+def test_cmd_up_dry_run_with_pending(capsys: pytest.CaptureFixture[str]) -> None:
+    mock_runner = MagicMock()
+    mock_plan = MagicMock()
+    mock_plan.to_apply = [MagicMock(id="001_a")]
+    mock_runner.plan_up.return_value = mock_plan
+    with (
+        patch("mongrator.cli._load_config"),
+        patch("pymongo.MongoClient", return_value=MagicMock()),
+        patch("mongrator.runner.SyncRunner", return_value=mock_runner),
+    ):
+        ns = parse("up", "--dry-run")
+        rc = _cmd_up(ns)
+    assert rc == 0
+    assert "001_a" in capsys.readouterr().out
+
+
+def test_cmd_up_dry_run_nothing_to_apply(capsys: pytest.CaptureFixture[str]) -> None:
+    mock_runner = MagicMock()
+    mock_plan = MagicMock()
+    mock_plan.to_apply = []
+    mock_runner.plan_up.return_value = mock_plan
+    with (
+        patch("mongrator.cli._load_config"),
+        patch("pymongo.MongoClient", return_value=MagicMock()),
+        patch("mongrator.runner.SyncRunner", return_value=mock_runner),
+    ):
+        ns = parse("up", "--dry-run")
+        rc = _cmd_up(ns)
+    assert rc == EXIT_NOTHING_TO_DO
+    assert "Nothing to apply" in capsys.readouterr().out
+
+
 # ---------------------------------------------------------------------------
 # _cmd_down
 # ---------------------------------------------------------------------------
@@ -349,6 +381,38 @@ def test_cmd_down_nothing_to_rollback(capsys: pytest.CaptureFixture[str]) -> Non
         patch("mongrator.runner.SyncRunner", return_value=mock_runner),
     ):
         ns = parse("down")
+        rc = _cmd_down(ns)
+    assert rc == EXIT_NOTHING_TO_DO
+    assert "Nothing to roll back" in capsys.readouterr().out
+
+
+def test_cmd_down_dry_run_with_pending(capsys: pytest.CaptureFixture[str]) -> None:
+    mock_runner = MagicMock()
+    mock_plan = MagicMock()
+    mock_plan.to_apply = [MagicMock(id="002_b")]
+    mock_runner.plan_down.return_value = mock_plan
+    with (
+        patch("mongrator.cli._load_config"),
+        patch("pymongo.MongoClient", return_value=MagicMock()),
+        patch("mongrator.runner.SyncRunner", return_value=mock_runner),
+    ):
+        ns = parse("down", "--dry-run")
+        rc = _cmd_down(ns)
+    assert rc == 0
+    assert "002_b" in capsys.readouterr().out
+
+
+def test_cmd_down_dry_run_nothing_to_rollback(capsys: pytest.CaptureFixture[str]) -> None:
+    mock_runner = MagicMock()
+    mock_plan = MagicMock()
+    mock_plan.to_apply = []
+    mock_runner.plan_down.return_value = mock_plan
+    with (
+        patch("mongrator.cli._load_config"),
+        patch("pymongo.MongoClient", return_value=MagicMock()),
+        patch("mongrator.runner.SyncRunner", return_value=mock_runner),
+    ):
+        ns = parse("down", "--dry-run")
         rc = _cmd_down(ns)
     assert rc == EXIT_NOTHING_TO_DO
     assert "Nothing to roll back" in capsys.readouterr().out

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from mongrator.cli import (
+    EXIT_NOTHING_TO_DO,
     _build_parser,
     _cmd_create,
     _cmd_down,
@@ -314,7 +315,7 @@ def test_cmd_up_nothing_to_apply(capsys: pytest.CaptureFixture[str]) -> None:
     ):
         ns = parse("up")
         rc = _cmd_up(ns)
-    assert rc == 0
+    assert rc == EXIT_NOTHING_TO_DO
     assert "Nothing to apply" in capsys.readouterr().out
 
 
@@ -349,7 +350,7 @@ def test_cmd_down_nothing_to_rollback(capsys: pytest.CaptureFixture[str]) -> Non
     ):
         ns = parse("down")
         rc = _cmd_down(ns)
-    assert rc == 0
+    assert rc == EXIT_NOTHING_TO_DO
     assert "Nothing to roll back" in capsys.readouterr().out
 
 


### PR DESCRIPTION
💁 These changes add a distinct exit code (4) for the \`up\` and \`down\` commands when no migrations need to be applied. This enables better scripting and CI integration — callers can distinguish "changes applied" (0) from "already up-to-date" (4) without parsing output.

Exit code 4 was chosen specifically to avoid collision with argparse's reserved exit code 2 (CLI usage errors).