### PR TITLE
feat(status): detect orphaned migration records

### DIFF
--- a/src/mongrator/cli.py
+++ b/src/mongrator/cli.py
@@ -175,9 +175,14 @@ def _cmd_status(args: argparse.Namespace) -> int:
     print(f"{'Migration':<{col_width}} {'Status':<10} {'Applied At'}")
     print("-" * (col_width + 30))
     for s in statuses:
-        state = "applied" if s.applied else "pending"
-        if s.applied and not s.checksum_ok:
+        if s.orphaned:
+            state = "ORPHANED"
+        elif s.applied and not s.checksum_ok:
             state = "MODIFIED"
+        elif s.applied:
+            state = "applied"
+        else:
+            state = "pending"
         applied_at = s.applied_at.isoformat() if s.applied_at else "-"
         print(f"{s.id:<{col_width}} {state:<10} {applied_at}")
     return 0

--- a/src/mongrator/migration.py
+++ b/src/mongrator/migration.py
@@ -55,3 +55,4 @@ class MigrationStatus:
     applied: bool
     applied_at: datetime | None = None
     checksum_ok: bool = True
+    orphaned: bool = False

--- a/src/mongrator/runner.py
+++ b/src/mongrator/runner.py
@@ -141,13 +141,18 @@ class SyncRunner:
         file_ids = {f.id for f in files}
         statuses: list[MigrationStatus] = []
         for f in files:
-            record = self._store.get_record(f.id)
-            checksum_ok = record is None or record["checksum"] == f.checksum
+            if f.id in applied:
+                record = self._store.get_record(f.id)
+                checksum_ok = record is None or record["checksum"] == f.checksum
+                applied_at = record["applied_at"] if record else None
+            else:
+                checksum_ok = True
+                applied_at = None
             statuses.append(
                 MigrationStatus(
                     id=f.id,
                     applied=f.id in applied,
-                    applied_at=record["applied_at"] if record else None,
+                    applied_at=applied_at,
                     checksum_ok=checksum_ok,
                 )
             )
@@ -251,13 +256,18 @@ class AsyncRunner:
         file_ids = {f.id for f in files}
         statuses: list[MigrationStatus] = []
         for f in files:
-            record = await self._store.get_record(f.id)
-            checksum_ok = record is None or record["checksum"] == f.checksum
+            if f.id in applied:
+                record = await self._store.get_record(f.id)
+                checksum_ok = record is None or record["checksum"] == f.checksum
+                applied_at = record["applied_at"] if record else None
+            else:
+                checksum_ok = True
+                applied_at = None
             statuses.append(
                 MigrationStatus(
                     id=f.id,
                     applied=f.id in applied,
-                    applied_at=record["applied_at"] if record else None,
+                    applied_at=applied_at,
                     checksum_ok=checksum_ok,
                 )
             )

--- a/src/mongrator/runner.py
+++ b/src/mongrator/runner.py
@@ -135,9 +135,10 @@ class SyncRunner:
             return rolled_back
 
     def status(self) -> list[MigrationStatus]:
-        """Return the status of every known migration."""
+        """Return the status of every known migration, including orphans."""
         files = loader.load(self._config)
         applied = self._store.get_applied()
+        file_ids = {f.id for f in files}
         statuses: list[MigrationStatus] = []
         for f in files:
             record = self._store.get_record(f.id)
@@ -148,6 +149,16 @@ class SyncRunner:
                     applied=f.id in applied,
                     applied_at=record["applied_at"] if record else None,
                     checksum_ok=checksum_ok,
+                )
+            )
+        for orphan_id in sorted(applied - file_ids):
+            record = self._store.get_record(orphan_id)
+            statuses.append(
+                MigrationStatus(
+                    id=orphan_id,
+                    applied=True,
+                    applied_at=record["applied_at"] if record else None,
+                    orphaned=True,
                 )
             )
         return statuses
@@ -234,9 +245,10 @@ class AsyncRunner:
             return rolled_back
 
     async def status(self) -> list[MigrationStatus]:
-        """Return the status of every known migration."""
+        """Return the status of every known migration, including orphans."""
         files = loader.load(self._config)
         applied = await self._store.get_applied()
+        file_ids = {f.id for f in files}
         statuses: list[MigrationStatus] = []
         for f in files:
             record = await self._store.get_record(f.id)
@@ -247,6 +259,16 @@ class AsyncRunner:
                     applied=f.id in applied,
                     applied_at=record["applied_at"] if record else None,
                     checksum_ok=checksum_ok,
+                )
+            )
+        for orphan_id in sorted(applied - file_ids):
+            record = await self._store.get_record(orphan_id)
+            statuses.append(
+                MigrationStatus(
+                    id=orphan_id,
+                    applied=True,
+                    applied_at=record["applied_at"] if record else None,
+                    orphaned=True,
                 )
             )
         return statuses

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -284,6 +284,26 @@ def test_cmd_status_shows_applied_and_pending(capsys: pytest.CaptureFixture[str]
     assert "pending" in out
 
 
+def test_cmd_status_shows_orphaned(capsys: pytest.CaptureFixture[str]) -> None:
+    statuses = [
+        MigrationStatus(id="001_a", applied=True, applied_at=datetime(2025, 1, 1, tzinfo=UTC)),
+        MigrationStatus(id="002_deleted", applied=True, applied_at=datetime(2025, 1, 2, tzinfo=UTC), orphaned=True),
+    ]
+    mock_runner = MagicMock()
+    mock_runner.status.return_value = statuses
+    with (
+        patch("mongrator.cli._load_config"),
+        patch("pymongo.MongoClient", return_value=MagicMock()),
+        patch("mongrator.runner.SyncRunner", return_value=mock_runner),
+    ):
+        ns = parse("status")
+        rc = _cmd_status(ns)
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "ORPHANED" in out
+    assert "002_deleted" in out
+
+
 # ---------------------------------------------------------------------------
 # _cmd_up
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -313,6 +313,35 @@ def test_sync_status_checksum_mismatch(tmp_path: Path) -> None:
     assert not statuses[0].checksum_ok
 
 
+def test_sync_status_detects_orphaned(tmp_path: Path) -> None:
+    runner, db, store = _sync_runner(tmp_path)
+    migrations = [_migration("001_a")]
+    store.get_applied.return_value = {"001_a", "002_deleted"}
+    store.get_record.side_effect = lambda mid: make_record(mid, "abc", "up", 5)
+
+    with patch("mongrator.runner.loader.load", return_value=migrations):
+        statuses = runner.status()
+
+    assert len(statuses) == 2
+    orphaned = [s for s in statuses if s.orphaned]
+    assert len(orphaned) == 1
+    assert orphaned[0].id == "002_deleted"
+    assert orphaned[0].applied is True
+
+
+def test_sync_status_no_orphans_when_all_files_present(tmp_path: Path) -> None:
+    runner, db, store = _sync_runner(tmp_path)
+    migrations = [_migration("001_a"), _migration("002_b")]
+    store.get_applied.return_value = {"001_a"}
+    store.get_record.side_effect = lambda mid: make_record(mid, "abc", "up", 5) if mid == "001_a" else None
+
+    with patch("mongrator.runner.loader.load", return_value=migrations):
+        statuses = runner.status()
+
+    assert len(statuses) == 2
+    assert all(not s.orphaned for s in statuses)
+
+
 # ---------------------------------------------------------------------------
 # SyncRunner.validate
 # ---------------------------------------------------------------------------
@@ -405,6 +434,23 @@ async def test_async_down_drop_index_ops_auto_rollback(tmp_path: Path) -> None:
         name="email_1",
         unique=True,
     )
+
+
+@pytest.mark.asyncio
+async def test_async_status_detects_orphaned(tmp_path: Path) -> None:
+    runner, db, store = _async_runner(tmp_path)
+    migrations = [_migration("001_a")]
+    store.get_applied.return_value = {"001_a", "002_deleted"}
+    store.get_record.side_effect = lambda mid: make_record(mid, "abc", "up", 5)
+
+    with patch("mongrator.runner.loader.load", return_value=migrations):
+        statuses = await runner.status()
+
+    assert len(statuses) == 2
+    orphaned = [s for s in statuses if s.orphaned]
+    assert len(orphaned) == 1
+    assert orphaned[0].id == "002_deleted"
+    assert orphaned[0].applied is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
💁 These changes surface orphaned migration records in `mongrator status`. Applied records in MongoDB that no longer have a corresponding file on disk now appear with an "ORPHANED" status, helping diagnose "nothing to apply" confusion when migration files are deleted.