### PR TITLE
docs(ops): explain ty type narrowing suppression in drop_index

### DIFF
--- a/src/mongrator/ops.py
+++ b/src/mongrator/ops.py
@@ -104,6 +104,9 @@ def drop_index(
     Operation instance that ran apply().
     """
     # Normalize dict keys to the list-of-tuples form pymongo expects.
+    # ty narrows isinstance(…, dict) to dict[object, object], losing the
+    # generic parameters, so the comprehension appears as list[tuple[object,
+    # object]] rather than list[tuple[str, int | str]].
     _norm_keys: list[tuple[str, int | str]] | None = None
     if isinstance(keys, dict):
         _norm_keys = [(k, v) for k, v in keys.items()]  # ty: ignore[invalid-assignment]


### PR DESCRIPTION
💁 These changes add a comment explaining why the `# ty: ignore[invalid-assignment]` directive is necessary in `drop_index`. The `ty` type checker narrows `isinstance(…, dict)` to `dict[object, object]`, losing generic parameters, which makes the comprehension appear as `list[tuple[object, object]]` instead of the annotated `list[tuple[str, int | str]]`.