### PR TITLE
feat(runner): support async migration functions in AsyncRunner

### DIFF
--- a/src/mongrator/runner.py
+++ b/src/mongrator/runner.py
@@ -6,6 +6,7 @@ AsyncRunner wraps a pymongo AsyncMongoClient.
 Both share the same non-IO logic via loader and planner.
 """
 
+import inspect
 import sys
 import time
 from typing import Any, Protocol, cast, runtime_checkable
@@ -79,6 +80,52 @@ def _run_down_migration(migration: MigrationFile, db: Any) -> None:
     if isinstance(result, list) and all(isinstance(op, Operation) for op in result):
         for op in reversed(cast(list[Operation], result)):
             op.revert(db)  # type: ignore[arg-type]
+        return
+    raise NoDownMethodError(migration.id)
+
+
+async def _async_run_up_migration(migration: MigrationFile, async_db: Any, sync_db: Any) -> None:
+    """Execute the up() callable, dispatching to async or sync path as needed.
+
+    If up() is a coroutine function, it receives the async database and is awaited.
+    If up() returns a list of Operations, those are applied using the sync database
+    (ops helpers are synchronous). Otherwise, the sync database is passed directly
+    for backwards compatibility.
+    """
+    up_fn = migration.up
+    if up_fn is None:
+        return
+    if inspect.iscoroutinefunction(up_fn):
+        await up_fn(async_db)
+        return
+    result = up_fn(sync_db)
+    if isinstance(result, list) and all(isinstance(op, Operation) for op in result):
+        for op in cast(list[Operation], result):
+            op.apply(sync_db)
+
+
+async def _async_run_down_migration(migration: MigrationFile, async_db: Any, sync_db: Any) -> None:
+    """Execute the down() callable, dispatching to async or sync path as needed.
+
+    If down() is a coroutine function, it receives the async database and is awaited.
+    If no down() exists, auto-rollback via ops is attempted using the sync database.
+    Otherwise, the sync database is passed for backwards compatibility.
+    """
+    down_fn = migration.down
+    if down_fn is not None:
+        if inspect.iscoroutinefunction(down_fn):
+            await down_fn(async_db)
+            return
+        down_fn(sync_db)
+        return
+    # Try auto-rollback via ops returned from up()
+    up_fn = migration.up
+    if up_fn is None:
+        raise NoDownMethodError(migration.id)
+    result = up_fn(sync_db)
+    if isinstance(result, list) and all(isinstance(op, Operation) for op in result):
+        for op in reversed(cast(list[Operation], result)):
+            op.revert(sync_db)
         return
     raise NoDownMethodError(migration.id)
 
@@ -193,8 +240,17 @@ class SyncRunner:
 class AsyncRunner:
     """Asynchronous migration runner backed by pymongo AsyncMongoClient.
 
-    Migration up()/down() functions always receive a synchronous pymongo Database
-    because ops helpers are synchronous. Only state tracking uses the async client.
+    Migration functions are dispatched based on their type:
+
+    - **Coroutine functions** (``async def up(db)``) receive the async database
+      and are awaited. This allows migrations to use ``await`` for non-blocking
+      I/O when running with ``--async``.
+    - **Regular functions** that return a ``list[Operation]`` (ops-based migrations)
+      continue to receive the sync database, since ops helpers are synchronous.
+    - **Regular functions** that perform raw pymongo calls also receive the sync
+      database, preserving backwards compatibility.
+
+    State tracking always uses the async client for non-blocking operation.
     """
 
     def __init__(  # type: ignore[type-arg]
@@ -204,15 +260,16 @@ class AsyncRunner:
         *,
         sync_client: "MongoClient | None" = None,
     ) -> None:
-        # Sync DB passed to migration functions — ops helpers are synchronous pymongo.
+        # Sync DB passed to sync migration functions and ops helpers.
         if sync_client is None:
             sync_client = MongoClient(config.uri)
         self._sync_client = sync_client
         self._db = sync_client[config.database]
+        # Async DB passed to coroutine migration functions.
+        self._async_db = client[config.database]
         # Async store for non-blocking state tracking.
-        async_db = client[config.database]
-        self._store = AsyncMongoStateStore(async_db[config.collection])
-        self._lock = AsyncMigrationLock(async_db[config.collection])
+        self._store = AsyncMongoStateStore(self._async_db[config.collection])
+        self._lock = AsyncMigrationLock(self._async_db[config.collection])
         self._config = config
 
     async def plan_up(self, target: MigrationId | None = None) -> MigrationPlan:
@@ -228,7 +285,11 @@ class AsyncRunner:
         return planner.plan_down(files, applied, steps)
 
     async def up(self, target: MigrationId | None = None) -> list[MigrationId]:
-        """Apply pending migrations, optionally up to `target`."""
+        """Apply pending migrations, optionally up to `target`.
+
+        Coroutine migration functions receive the async database and are awaited;
+        sync functions and ops-based migrations use the sync database.
+        """
         async with self._lock:
             files = loader.load(self._config)
             applied = await self._store.get_applied()
@@ -236,14 +297,18 @@ class AsyncRunner:
             applied_ids: list[MigrationId] = []
             for migration in plan.to_apply:
                 start = time.monotonic()
-                _run_up_migration(migration, self._db)
+                await _async_run_up_migration(migration, self._async_db, self._db)
                 duration_ms = int((time.monotonic() - start) * 1000)
                 await self._store.record_applied(make_record(migration.id, migration.checksum, "up", duration_ms))
                 applied_ids.append(migration.id)
             return applied_ids
 
     async def down(self, steps: int = 1) -> list[MigrationId]:
-        """Roll back the most recently applied migrations."""
+        """Roll back the most recently applied migrations.
+
+        Coroutine migration functions receive the async database and are awaited;
+        sync functions and ops-based migrations use the sync database.
+        """
         async with self._lock:
             files = loader.load(self._config)
             applied = await self._store.get_applied()
@@ -251,7 +316,7 @@ class AsyncRunner:
             rolled_back: list[MigrationId] = []
             for migration in plan.to_apply:
                 start = time.monotonic()
-                _run_down_migration(migration, self._db)
+                await _async_run_down_migration(migration, self._async_db, self._db)
                 duration_ms = int((time.monotonic() - start) * 1000)
                 await self._store.record_applied(make_record(migration.id, migration.checksum, "down", duration_ms))
                 rolled_back.append(migration.id)

--- a/src/mongrator/runner.py
+++ b/src/mongrator/runner.py
@@ -96,7 +96,10 @@ async def _async_run_up_migration(migration: MigrationFile, async_db: Any, sync_
     if up_fn is None:
         return
     if inspect.iscoroutinefunction(up_fn):
-        await up_fn(async_db)
+        result = await up_fn(async_db)
+        if isinstance(result, list) and all(isinstance(op, Operation) for op in result):
+            for op in cast(list[Operation], result):
+                op.apply(sync_db)
         return
     result = up_fn(sync_db)
     if isinstance(result, list) and all(isinstance(op, Operation) for op in result):

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -721,13 +721,37 @@ async def test_async_down_coroutine_receives_async_db(tmp_path: Path) -> None:
 async def test_async_up_sync_function_receives_sync_db(tmp_path: Path) -> None:
     """Regular (non-coroutine) up() functions should still receive the sync database."""
     runner, sync_db, store = _async_runner(tmp_path)
-    migrations = [_migration("001_a")]
+    up_fn = MagicMock(return_value=None)
+    migrations = [_migration("001_a", ops_fn=up_fn)]
     store.get_applied.return_value = set()
 
     with patch("mongrator.runner.loader.load", return_value=migrations):
         applied = await runner.up()
 
     assert applied == ["001_a"]
+    up_fn.assert_called_once_with(sync_db)
+    assert up_fn.call_args[0][0] is not runner._async_db
+
+
+@pytest.mark.asyncio
+async def test_async_up_coroutine_returning_ops_applies_them(tmp_path: Path) -> None:
+    """Coroutine up() that returns list[Operation] should apply ops via the sync database."""
+    runner, sync_db, store = _async_runner(tmp_path)
+
+    async def async_up_with_ops(db: Any) -> list:
+        return [create_index("col", {"field": 1})]
+
+    mod = types.ModuleType("_test_async_ops_001")
+    setattr(mod, "up", async_up_with_ops)
+    migration = MigrationFile(id="001_a", path=Path("001_a.py"), checksum="abc", module=mod)
+
+    store.get_applied.return_value = set()
+
+    with patch("mongrator.runner.loader.load", return_value=[migration]):
+        applied = await runner.up()
+
+    assert applied == ["001_a"]
+    sync_db["col"].create_index.assert_called_once()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -57,16 +57,46 @@ def _sync_runner(tmp_path: Path) -> tuple[SyncRunner, MagicMock, MagicMock]:
 
 
 def _async_runner(tmp_path: Path) -> tuple[AsyncRunner, MagicMock, AsyncMock]:
-    """Return (runner, mock_db, mock_store)."""
-    mock_db = MagicMock()
+    """Return (runner, mock_sync_db, mock_store).
+
+    The runner's sync _db is set to mock_sync_db.  The async _async_db is a
+    separate MagicMock accessible via ``runner._async_db``.
+    """
+    mock_sync_db = MagicMock()
+    mock_async_db = MagicMock()
     mock_client = MagicMock()
-    mock_client.__getitem__ = MagicMock(return_value=mock_db)
+    mock_client.__getitem__ = MagicMock(return_value=mock_async_db)
     mock_store = AsyncMock()
     config = _config(tmp_path)
     runner = AsyncRunner(mock_client, config)
+    runner._db = mock_sync_db
     runner._store = mock_store
     runner._lock = AsyncMock()
-    return runner, mock_db, mock_store
+    return runner, mock_sync_db, mock_store
+
+
+def _async_migration(
+    migration_id: str,
+    *,
+    has_async_down: bool = False,
+) -> MigrationFile:
+    """Create a migration with async up() and optionally async down()."""
+    mod = types.ModuleType(f"_test_async_{migration_id}")
+
+    async def async_up(db: Any) -> None:
+        # Record calls on the db mock for assertions.
+        db.async_up_called(migration_id)
+
+    setattr(mod, "up", async_up)
+
+    if has_async_down:
+
+        async def async_down(db: Any) -> None:
+            db.async_down_called(migration_id)
+
+        setattr(mod, "down", async_down)
+
+    return MigrationFile(id=migration_id, path=Path(f"{migration_id}.py"), checksum="abc", module=mod)
 
 
 # ---------------------------------------------------------------------------
@@ -648,3 +678,68 @@ async def test_async_plan_down_returns_rollback(tmp_path: Path) -> None:
 
     assert [m.id for m in plan.to_apply] == ["002_b"]
     store.record_applied.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# AsyncRunner — async migration functions
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_async_up_coroutine_receives_async_db(tmp_path: Path) -> None:
+    """Coroutine up() functions should receive the async database and be awaited."""
+    runner, sync_db, store = _async_runner(tmp_path)
+    migrations = [_async_migration("001_a")]
+    store.get_applied.return_value = set()
+
+    with patch("mongrator.runner.loader.load", return_value=migrations):
+        applied = await runner.up()
+
+    assert applied == ["001_a"]
+    # The async up() calls db.async_up_called — verify it was called on the async db.
+    runner._async_db.async_up_called.assert_called_once_with("001_a")
+    # Sync db should NOT have been called.
+    sync_db.async_up_called.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_async_down_coroutine_receives_async_db(tmp_path: Path) -> None:
+    """Coroutine down() functions should receive the async database and be awaited."""
+    runner, sync_db, store = _async_runner(tmp_path)
+    migrations = [_async_migration("001_a", has_async_down=True)]
+    store.get_applied.return_value = {"001_a"}
+
+    with patch("mongrator.runner.loader.load", return_value=migrations):
+        rolled_back = await runner.down()
+
+    assert rolled_back == ["001_a"]
+    runner._async_db.async_down_called.assert_called_once_with("001_a")
+    sync_db.async_down_called.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_async_up_sync_function_receives_sync_db(tmp_path: Path) -> None:
+    """Regular (non-coroutine) up() functions should still receive the sync database."""
+    runner, sync_db, store = _async_runner(tmp_path)
+    migrations = [_migration("001_a")]
+    store.get_applied.return_value = set()
+
+    with patch("mongrator.runner.loader.load", return_value=migrations):
+        applied = await runner.up()
+
+    assert applied == ["001_a"]
+
+
+@pytest.mark.asyncio
+async def test_async_up_ops_based_uses_sync_db(tmp_path: Path) -> None:
+    """Ops-based migrations should use the sync database for apply()."""
+    runner, sync_db, store = _async_runner(tmp_path)
+    migrations = [_migration("001_a", ops_based=True)]
+    store.get_applied.return_value = set()
+
+    with patch("mongrator.runner.loader.load", return_value=migrations):
+        applied = await runner.up()
+
+    assert applied == ["001_a"]
+    # Ops apply via sync db — create_index should be called on the sync mock.
+    sync_db["col"].create_index.assert_called_once()


### PR DESCRIPTION
💁 These changes allow migration functions to be written as coroutines (`async def up(db)`) when using `--async`. The `AsyncRunner` now detects coroutine functions via `inspect.iscoroutinefunction` and passes them the async database, awaiting the result. Regular sync functions and ops-based migrations continue to receive the sync database for backwards compatibility.