### PR TITLE
feat(runner): add optional transaction support for migrations

### DIFF
--- a/src/mongrator/cli.py
+++ b/src/mongrator/cli.py
@@ -76,6 +76,11 @@ def _build_parser() -> argparse.ArgumentParser:
     p_up.add_argument("--target", metavar="ID", help="apply only up to this migration ID")
     p_up.add_argument("--async", dest="use_async", action="store_true", help="use async runner")
     p_up.add_argument("--dry-run", action="store_true", help="show which migrations would be applied without executing")
+    p_up.add_argument(
+        "--transactional",
+        action="store_true",
+        help="wrap each migration in a MongoDB transaction (requires replica set)",
+    )
 
     # down
     p_down = sub.add_parser("down", help="roll back applied migrations")
@@ -85,6 +90,11 @@ def _build_parser() -> argparse.ArgumentParser:
     p_down.add_argument("--async", dest="use_async", action="store_true", help="use async runner")
     p_down.add_argument(
         "--dry-run", action="store_true", help="show which migrations would be rolled back without executing"
+    )
+    p_down.add_argument(
+        "--transactional",
+        action="store_true",
+        help="wrap each migration in a MongoDB transaction (requires replica set)",
     )
 
     # validate
@@ -192,7 +202,7 @@ def _cmd_status(args: argparse.Namespace) -> int:
 def _cmd_up(args: argparse.Namespace) -> int:
     config = _load_config(args)
     if args.use_async:
-        return asyncio.run(_async_up(config, args.target, dry_run=args.dry_run))
+        return asyncio.run(_async_up(config, args.target, dry_run=args.dry_run, transactional=args.transactional))
     from .runner import SyncRunner
 
     with pymongo.MongoClient(config.uri) as client:
@@ -201,7 +211,7 @@ def _cmd_up(args: argparse.Namespace) -> int:
             plan = runner.plan_up(target=args.target)
             _print_dry_run(plan, direction="up")
             return EXIT_NOTHING_TO_DO if not plan.to_apply else 0
-        applied = runner.up(target=args.target)
+        applied = runner.up(target=args.target, transactional=args.transactional)
     if applied:
         for mid in applied:
             print(f"  applied  {mid}")
@@ -210,7 +220,13 @@ def _cmd_up(args: argparse.Namespace) -> int:
     return EXIT_NOTHING_TO_DO
 
 
-async def _async_up(config: MigratorConfig, target: str | None, *, dry_run: bool = False) -> int:
+async def _async_up(
+    config: MigratorConfig,
+    target: str | None,
+    *,
+    dry_run: bool = False,
+    transactional: bool = False,
+) -> int:
     from .runner import AsyncRunner
 
     with pymongo.MongoClient(config.uri) as sync_client:
@@ -220,7 +236,7 @@ async def _async_up(config: MigratorConfig, target: str | None, *, dry_run: bool
                 plan = await runner.plan_up(target=target)
                 _print_dry_run(plan, direction="up")
                 return EXIT_NOTHING_TO_DO if not plan.to_apply else 0
-            applied = await runner.up(target=target)
+            applied = await runner.up(target=target, transactional=transactional)
     if applied:
         for mid in applied:
             print(f"  applied  {mid}")
@@ -232,7 +248,7 @@ async def _async_up(config: MigratorConfig, target: str | None, *, dry_run: bool
 def _cmd_down(args: argparse.Namespace) -> int:
     config = _load_config(args)
     if args.use_async:
-        return asyncio.run(_async_down(config, args.steps, dry_run=args.dry_run))
+        return asyncio.run(_async_down(config, args.steps, dry_run=args.dry_run, transactional=args.transactional))
     from .runner import SyncRunner
 
     with pymongo.MongoClient(config.uri) as client:
@@ -241,7 +257,7 @@ def _cmd_down(args: argparse.Namespace) -> int:
             plan = runner.plan_down(steps=args.steps)
             _print_dry_run(plan, direction="down")
             return EXIT_NOTHING_TO_DO if not plan.to_apply else 0
-        rolled_back = runner.down(steps=args.steps)
+        rolled_back = runner.down(steps=args.steps, transactional=args.transactional)
     if rolled_back:
         for mid in rolled_back:
             print(f"  rolled back  {mid}")
@@ -250,7 +266,13 @@ def _cmd_down(args: argparse.Namespace) -> int:
     return EXIT_NOTHING_TO_DO
 
 
-async def _async_down(config: MigratorConfig, steps: int, *, dry_run: bool = False) -> int:
+async def _async_down(
+    config: MigratorConfig,
+    steps: int,
+    *,
+    dry_run: bool = False,
+    transactional: bool = False,
+) -> int:
     from .runner import AsyncRunner
 
     with pymongo.MongoClient(config.uri) as sync_client:
@@ -260,7 +282,7 @@ async def _async_down(config: MigratorConfig, steps: int, *, dry_run: bool = Fal
                 plan = await runner.plan_down(steps=steps)
                 _print_dry_run(plan, direction="down")
                 return EXIT_NOTHING_TO_DO if not plan.to_apply else 0
-            rolled_back = await runner.down(steps=steps)
+            rolled_back = await runner.down(steps=steps, transactional=transactional)
     if rolled_back:
         for mid in rolled_back:
             print(f"  rolled back  {mid}")

--- a/src/mongrator/exceptions.py
+++ b/src/mongrator/exceptions.py
@@ -84,3 +84,14 @@ class MigrationLockError(MigratorError):
             "Another migration may be in progress. "
             "If this is stale, the lock will expire automatically."
         )
+
+
+class TransactionNotSupportedError(MigratorError):
+    """The MongoDB server does not support transactions (requires a replica set)."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            "Transactions require a MongoDB replica set. "
+            "The connected server does not support transactions. "
+            "Run without --transactional or configure a replica set."
+        )

--- a/src/mongrator/exceptions.py
+++ b/src/mongrator/exceptions.py
@@ -87,11 +87,15 @@ class MigrationLockError(MigratorError):
 
 
 class TransactionNotSupportedError(MigratorError):
-    """The MongoDB server does not support transactions (requires a replica set)."""
+    """The MongoDB server does not support multi-document transactions.
+
+    Transactions require either a replica set or a sharded cluster (mongos).
+    Standalone servers do not support them.
+    """
 
     def __init__(self) -> None:
         super().__init__(
-            "Transactions require a MongoDB replica set. "
+            "Transactions require a MongoDB replica set or sharded cluster. "
             "The connected server does not support transactions. "
-            "Run without --transactional or configure a replica set."
+            "Run without --transactional or connect to a replica set or sharded cluster."
         )

--- a/src/mongrator/runner.py
+++ b/src/mongrator/runner.py
@@ -15,7 +15,7 @@ from pymongo import AsyncMongoClient, MongoClient
 
 from . import loader, planner
 from .config import MigratorConfig
-from .exceptions import ChecksumMismatchError, NoDownMethodError
+from .exceptions import ChecksumMismatchError, NoDownMethodError, TransactionNotSupportedError
 from .migration import MigrationFile, MigrationId, MigrationStatus
 from .ops import Operation
 from .planner import MigrationPlan
@@ -26,8 +26,8 @@ from .state import AsyncMigrationLock, AsyncMongoStateStore, SyncMigrationLock, 
 class MigrationRunner(Protocol):
     def plan_up(self, target: MigrationId | None = None) -> MigrationPlan: ...
     def plan_down(self, steps: int = 1) -> MigrationPlan: ...
-    def up(self, target: MigrationId | None = None) -> list[MigrationId]: ...
-    def down(self, steps: int = 1) -> list[MigrationId]: ...
+    def up(self, target: MigrationId | None = None, *, transactional: bool = False) -> list[MigrationId]: ...
+    def down(self, steps: int = 1, *, transactional: bool = False) -> list[MigrationId]: ...
     def status(self) -> list[MigrationStatus]: ...
     def validate(self) -> list[ChecksumMismatchError]: ...
 
@@ -36,8 +36,8 @@ class MigrationRunner(Protocol):
 class AsyncMigrationRunner(Protocol):
     async def plan_up(self, target: MigrationId | None = None) -> MigrationPlan: ...
     async def plan_down(self, steps: int = 1) -> MigrationPlan: ...
-    async def up(self, target: MigrationId | None = None) -> list[MigrationId]: ...
-    async def down(self, steps: int = 1) -> list[MigrationId]: ...
+    async def up(self, target: MigrationId | None = None, *, transactional: bool = False) -> list[MigrationId]: ...
+    async def down(self, steps: int = 1, *, transactional: bool = False) -> list[MigrationId]: ...
     async def status(self) -> list[MigrationStatus]: ...
     async def validate(self) -> list[ChecksumMismatchError]: ...
 
@@ -133,10 +133,27 @@ async def _async_run_down_migration(migration: MigrationFile, async_db: Any, syn
     raise NoDownMethodError(migration.id)
 
 
+def _check_transaction_support(client: Any) -> None:
+    """Verify the server supports transactions (replica set or sharded cluster).
+
+    Raises TransactionNotSupportedError if the topology does not support
+    multi-document transactions.
+    """
+    try:
+        with client.start_session() as session:
+            session.start_transaction()
+            session.abort_transaction()
+    except Exception as exc:  # noqa: BLE001
+        # pymongo raises various errors when transactions are unsupported
+        # (e.g. ConfigurationError for standalone servers).
+        raise TransactionNotSupportedError from exc
+
+
 class SyncRunner:
     """Synchronous migration runner backed by pymongo."""
 
     def __init__(self, client: "MongoClient", config: MigratorConfig) -> None:  # type: ignore[type-arg]
+        self._client = client
         self._db = client[config.database]
         self._store = SyncStateStore(self._db[config.collection])
         self._lock = SyncMigrationLock(self._db[config.collection])
@@ -154,8 +171,17 @@ class SyncRunner:
         applied = self._store.get_applied()
         return planner.plan_down(files, applied, steps)
 
-    def up(self, target: MigrationId | None = None) -> list[MigrationId]:
-        """Apply pending migrations, optionally up to `target`."""
+    def up(self, target: MigrationId | None = None, *, transactional: bool = False) -> list[MigrationId]:
+        """Apply pending migrations, optionally up to `target`.
+
+        Args:
+            target: Stop after applying this migration ID.
+            transactional: When True, wrap each migration in a MongoDB
+                transaction. Requires a replica set; raises
+                ``TransactionNotSupportedError`` otherwise.
+        """
+        if transactional:
+            _check_transaction_support(self._client)
         with self._lock:
             files = loader.load(self._config)
             applied = self._store.get_applied()
@@ -163,14 +189,28 @@ class SyncRunner:
             applied_ids: list[MigrationId] = []
             for migration in plan.to_apply:
                 start = time.monotonic()
-                _run_up_migration(migration, self._db)
+                if transactional:
+                    with self._client.start_session() as session:
+                        with session.start_transaction():
+                            _run_up_migration(migration, self._db)
+                else:
+                    _run_up_migration(migration, self._db)
                 duration_ms = int((time.monotonic() - start) * 1000)
                 self._store.record_applied(make_record(migration.id, migration.checksum, "up", duration_ms))
                 applied_ids.append(migration.id)
             return applied_ids
 
-    def down(self, steps: int = 1) -> list[MigrationId]:
-        """Roll back the most recently applied migrations."""
+    def down(self, steps: int = 1, *, transactional: bool = False) -> list[MigrationId]:
+        """Roll back the most recently applied migrations.
+
+        Args:
+            steps: Number of migrations to roll back.
+            transactional: When True, wrap each migration in a MongoDB
+                transaction. Requires a replica set; raises
+                ``TransactionNotSupportedError`` otherwise.
+        """
+        if transactional:
+            _check_transaction_support(self._client)
         with self._lock:
             files = loader.load(self._config)
             applied = self._store.get_applied()
@@ -178,7 +218,12 @@ class SyncRunner:
             rolled_back: list[MigrationId] = []
             for migration in plan.to_apply:
                 start = time.monotonic()
-                _run_down_migration(migration, self._db)
+                if transactional:
+                    with self._client.start_session() as session:
+                        with session.start_transaction():
+                            _run_down_migration(migration, self._db)
+                else:
+                    _run_down_migration(migration, self._db)
                 duration_ms = int((time.monotonic() - start) * 1000)
                 self._store.record_applied(make_record(migration.id, migration.checksum, "down", duration_ms))
                 rolled_back.append(migration.id)
@@ -287,12 +332,20 @@ class AsyncRunner:
         applied = await self._store.get_applied()
         return planner.plan_down(files, applied, steps)
 
-    async def up(self, target: MigrationId | None = None) -> list[MigrationId]:
+    async def up(self, target: MigrationId | None = None, *, transactional: bool = False) -> list[MigrationId]:
         """Apply pending migrations, optionally up to `target`.
 
         Coroutine migration functions receive the async database and are awaited;
         sync functions and ops-based migrations use the sync database.
+
+        Args:
+            target: Stop after applying this migration ID.
+            transactional: When True, wrap each migration in a MongoDB
+                transaction. Requires a replica set; raises
+                ``TransactionNotSupportedError`` otherwise.
         """
+        if transactional:
+            _check_transaction_support(self._sync_client)
         async with self._lock:
             files = loader.load(self._config)
             applied = await self._store.get_applied()
@@ -300,18 +353,31 @@ class AsyncRunner:
             applied_ids: list[MigrationId] = []
             for migration in plan.to_apply:
                 start = time.monotonic()
-                await _async_run_up_migration(migration, self._async_db, self._db)
+                if transactional:
+                    with self._sync_client.start_session() as session:
+                        with session.start_transaction():
+                            await _async_run_up_migration(migration, self._async_db, self._db)
+                else:
+                    await _async_run_up_migration(migration, self._async_db, self._db)
                 duration_ms = int((time.monotonic() - start) * 1000)
                 await self._store.record_applied(make_record(migration.id, migration.checksum, "up", duration_ms))
                 applied_ids.append(migration.id)
             return applied_ids
 
-    async def down(self, steps: int = 1) -> list[MigrationId]:
+    async def down(self, steps: int = 1, *, transactional: bool = False) -> list[MigrationId]:
         """Roll back the most recently applied migrations.
 
         Coroutine migration functions receive the async database and are awaited;
         sync functions and ops-based migrations use the sync database.
+
+        Args:
+            steps: Number of migrations to roll back.
+            transactional: When True, wrap each migration in a MongoDB
+                transaction. Requires a replica set; raises
+                ``TransactionNotSupportedError`` otherwise.
         """
+        if transactional:
+            _check_transaction_support(self._sync_client)
         async with self._lock:
             files = loader.load(self._config)
             applied = await self._store.get_applied()
@@ -319,7 +385,12 @@ class AsyncRunner:
             rolled_back: list[MigrationId] = []
             for migration in plan.to_apply:
                 start = time.monotonic()
-                await _async_run_down_migration(migration, self._async_db, self._db)
+                if transactional:
+                    with self._sync_client.start_session() as session:
+                        with session.start_transaction():
+                            await _async_run_down_migration(migration, self._async_db, self._db)
+                else:
+                    await _async_run_down_migration(migration, self._async_db, self._db)
                 duration_ms = int((time.monotonic() - start) * 1000)
                 await self._store.record_applied(make_record(migration.id, migration.checksum, "down", duration_ms))
                 rolled_back.append(migration.id)

--- a/src/mongrator/runner.py
+++ b/src/mongrator/runner.py
@@ -133,20 +133,72 @@ async def _async_run_down_migration(migration: MigrationFile, async_db: Any, syn
     raise NoDownMethodError(migration.id)
 
 
+class _SessionBoundCollection:
+    """Wraps a pymongo Collection, injecting ``session=`` into every call."""
+
+    def __init__(self, collection: Any, session: Any) -> None:
+        self._collection = collection
+        self._session = session
+
+    def __getitem__(self, name: str) -> "_SessionBoundCollection":
+        return _SessionBoundCollection(self._collection[name], self._session)
+
+    def __getattr__(self, name: str) -> Any:
+        attr = getattr(self._collection, name)
+        if callable(attr):
+            session = self._session
+
+            def _bound(*args: Any, **kwargs: Any) -> Any:
+                kwargs.setdefault("session", session)
+                return attr(*args, **kwargs)
+
+            return _bound
+        return attr
+
+
+class _SessionBoundDatabase:
+    """Wraps a pymongo Database, injecting ``session=`` into every collection/db call.
+
+    Passed to migration functions and ops helpers when running under a
+    transaction so that every pymongo operation is part of the session.
+    """
+
+    def __init__(self, db: Any, session: Any) -> None:
+        self._db = db
+        self._session = session
+
+    def __getitem__(self, name: str) -> _SessionBoundCollection:
+        return _SessionBoundCollection(self._db[name], self._session)
+
+    def __getattr__(self, name: str) -> Any:
+        attr = getattr(self._db, name)
+        # Collection accessed via attribute (e.g. db.users)
+        if hasattr(attr, "insert_one"):
+            return _SessionBoundCollection(attr, self._session)
+        if callable(attr):
+            session = self._session
+
+            def _bound(*args: Any, **kwargs: Any) -> Any:
+                kwargs.setdefault("session", session)
+                return attr(*args, **kwargs)
+
+            return _bound
+        return attr
+
+
 def _check_transaction_support(client: Any) -> None:
     """Verify the server supports transactions (replica set or sharded cluster).
 
-    Raises TransactionNotSupportedError if the topology does not support
-    multi-document transactions.
+    Issues a ``hello`` command to inspect the topology. Connection and
+    authentication errors propagate as-is. Only raises
+    TransactionNotSupportedError when the server is confirmed to be a
+    standalone (neither a replica set member nor a mongos router).
     """
-    try:
-        with client.start_session() as session:
-            session.start_transaction()
-            session.abort_transaction()
-    except Exception as exc:  # noqa: BLE001
-        # pymongo raises various errors when transactions are unsupported
-        # (e.g. ConfigurationError for standalone servers).
-        raise TransactionNotSupportedError from exc
+    result = client.admin.command("hello")
+    is_replica_set = bool(result.get("setName"))
+    is_sharded = result.get("msg") == "isdbgrid"
+    if not (is_replica_set or is_sharded):
+        raise TransactionNotSupportedError
 
 
 class SyncRunner:
@@ -192,7 +244,7 @@ class SyncRunner:
                 if transactional:
                     with self._client.start_session() as session:
                         with session.start_transaction():
-                            _run_up_migration(migration, self._db)
+                            _run_up_migration(migration, _SessionBoundDatabase(self._db, session))
                 else:
                     _run_up_migration(migration, self._db)
                 duration_ms = int((time.monotonic() - start) * 1000)
@@ -221,7 +273,7 @@ class SyncRunner:
                 if transactional:
                     with self._client.start_session() as session:
                         with session.start_transaction():
-                            _run_down_migration(migration, self._db)
+                            _run_down_migration(migration, _SessionBoundDatabase(self._db, session))
                 else:
                     _run_down_migration(migration, self._db)
                 duration_ms = int((time.monotonic() - start) * 1000)
@@ -356,7 +408,9 @@ class AsyncRunner:
                 if transactional:
                     with self._sync_client.start_session() as session:
                         with session.start_transaction():
-                            await _async_run_up_migration(migration, self._async_db, self._db)
+                            await _async_run_up_migration(
+                                migration, self._async_db, _SessionBoundDatabase(self._db, session)
+                            )
                 else:
                     await _async_run_up_migration(migration, self._async_db, self._db)
                 duration_ms = int((time.monotonic() - start) * 1000)
@@ -388,7 +442,9 @@ class AsyncRunner:
                 if transactional:
                     with self._sync_client.start_session() as session:
                         with session.start_transaction():
-                            await _async_run_down_migration(migration, self._async_db, self._db)
+                            await _async_run_down_migration(
+                                migration, self._async_db, _SessionBoundDatabase(self._db, session)
+                            )
                 else:
                     await _async_run_down_migration(migration, self._async_db, self._db)
                 duration_ms = int((time.monotonic() - start) * 1000)

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -127,6 +127,16 @@ def test_up_dry_run_default() -> None:
     assert ns.dry_run is False
 
 
+def test_up_transactional_default() -> None:
+    ns = parse("up")
+    assert ns.transactional is False
+
+
+def test_up_transactional_flag() -> None:
+    ns = parse("up", "--transactional")
+    assert ns.transactional is True
+
+
 # ---------------------------------------------------------------------------
 # down
 # ---------------------------------------------------------------------------
@@ -157,6 +167,16 @@ def test_down_dry_run_flag() -> None:
 def test_down_dry_run_default() -> None:
     ns = parse("down")
     assert ns.dry_run is False
+
+
+def test_down_transactional_default() -> None:
+    ns = parse("down")
+    assert ns.transactional is False
+
+
+def test_down_transactional_flag() -> None:
+    ns = parse("down", "--transactional")
+    assert ns.transactional is True
 
 
 def test_down_invalid_steps_type_exits() -> None:
@@ -355,6 +375,32 @@ def test_cmd_up_dry_run_with_pending(capsys: pytest.CaptureFixture[str]) -> None
     assert "001_a" in capsys.readouterr().out
 
 
+def test_cmd_up_passes_transactional_false_by_default(capsys: pytest.CaptureFixture[str]) -> None:
+    mock_runner = MagicMock()
+    mock_runner.up.return_value = []
+    with (
+        patch("mongrator.cli._load_config"),
+        patch("pymongo.MongoClient", return_value=MagicMock()),
+        patch("mongrator.runner.SyncRunner", return_value=mock_runner),
+    ):
+        ns = parse("up")
+        _cmd_up(ns)
+    mock_runner.up.assert_called_once_with(target=None, transactional=False)
+
+
+def test_cmd_up_passes_transactional_true(capsys: pytest.CaptureFixture[str]) -> None:
+    mock_runner = MagicMock()
+    mock_runner.up.return_value = []
+    with (
+        patch("mongrator.cli._load_config"),
+        patch("pymongo.MongoClient", return_value=MagicMock()),
+        patch("mongrator.runner.SyncRunner", return_value=mock_runner),
+    ):
+        ns = parse("up", "--transactional")
+        _cmd_up(ns)
+    mock_runner.up.assert_called_once_with(target=None, transactional=True)
+
+
 def test_cmd_up_dry_run_nothing_to_apply(capsys: pytest.CaptureFixture[str]) -> None:
     mock_runner = MagicMock()
     mock_plan = MagicMock()
@@ -420,6 +466,32 @@ def test_cmd_down_dry_run_with_pending(capsys: pytest.CaptureFixture[str]) -> No
         rc = _cmd_down(ns)
     assert rc == 0
     assert "002_b" in capsys.readouterr().out
+
+
+def test_cmd_down_passes_transactional_false_by_default(capsys: pytest.CaptureFixture[str]) -> None:
+    mock_runner = MagicMock()
+    mock_runner.down.return_value = []
+    with (
+        patch("mongrator.cli._load_config"),
+        patch("pymongo.MongoClient", return_value=MagicMock()),
+        patch("mongrator.runner.SyncRunner", return_value=mock_runner),
+    ):
+        ns = parse("down")
+        _cmd_down(ns)
+    mock_runner.down.assert_called_once_with(steps=1, transactional=False)
+
+
+def test_cmd_down_passes_transactional_true(capsys: pytest.CaptureFixture[str]) -> None:
+    mock_runner = MagicMock()
+    mock_runner.down.return_value = []
+    with (
+        patch("mongrator.cli._load_config"),
+        patch("pymongo.MongoClient", return_value=MagicMock()),
+        patch("mongrator.runner.SyncRunner", return_value=mock_runner),
+    ):
+        ns = parse("down", "--transactional")
+        _cmd_down(ns)
+    mock_runner.down.assert_called_once_with(steps=1, transactional=True)
 
 
 def test_cmd_down_dry_run_nothing_to_rollback(capsys: pytest.CaptureFixture[str]) -> None:

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -12,6 +12,7 @@ from mongrator.exceptions import (
     MigrationNotFoundError,
     MigratorError,
     NoDownMethodError,
+    TransactionNotSupportedError,
 )
 
 
@@ -25,6 +26,7 @@ def test_all_errors_are_migrator_errors() -> None:
         NoDownMethodError,
         MigrationNotFoundError,
         MigrationLockError,
+        TransactionNotSupportedError,
     ):
         assert issubclass(cls, MigratorError)
 
@@ -76,6 +78,14 @@ def test_migration_lock_error() -> None:
     err = MigrationLockError()
     assert "lock" in str(err).lower()
     assert isinstance(err, MigratorError)
+
+
+def test_transaction_not_supported_error() -> None:
+    err = TransactionNotSupportedError()
+    assert isinstance(err, MigratorError)
+    msg = str(err).lower()
+    assert "replica set" in msg
+    assert "sharded" in msg
 
 
 def test_errors_are_catchable_as_base() -> None:

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -8,10 +8,10 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from mongrator.config import MigratorConfig
-from mongrator.exceptions import MigrationLockError, NoDownMethodError
+from mongrator.exceptions import MigrationLockError, NoDownMethodError, TransactionNotSupportedError
 from mongrator.migration import MigrationFile
 from mongrator.ops import create_index, drop_index
-from mongrator.runner import AsyncRunner, SyncRunner
+from mongrator.runner import AsyncRunner, SyncRunner, _check_transaction_support
 from mongrator.state import make_record
 
 # ---------------------------------------------------------------------------
@@ -97,6 +97,101 @@ def _async_migration(
         setattr(mod, "down", async_down)
 
     return MigrationFile(id=migration_id, path=Path(f"{migration_id}.py"), checksum="abc", module=mod)
+
+
+# ---------------------------------------------------------------------------
+# _check_transaction_support
+# ---------------------------------------------------------------------------
+
+
+def test_check_transaction_support_raises_for_standalone() -> None:
+    client = MagicMock()
+    client.admin.command.return_value = {"isWritablePrimary": True}
+    with pytest.raises(TransactionNotSupportedError):
+        _check_transaction_support(client)
+
+
+def test_check_transaction_support_passes_for_replica_set() -> None:
+    client = MagicMock()
+    client.admin.command.return_value = {"isWritablePrimary": True, "setName": "rs0"}
+    _check_transaction_support(client)  # should not raise
+
+
+def test_check_transaction_support_passes_for_sharded_cluster() -> None:
+    client = MagicMock()
+    client.admin.command.return_value = {"msg": "isdbgrid"}
+    _check_transaction_support(client)  # should not raise
+
+
+def test_check_transaction_support_propagates_connection_error() -> None:
+    client = MagicMock()
+    client.admin.command.side_effect = ConnectionError("unreachable")
+    with pytest.raises(ConnectionError):
+        _check_transaction_support(client)
+
+
+# ---------------------------------------------------------------------------
+# SyncRunner transactional — session injection
+# ---------------------------------------------------------------------------
+
+
+def _transactional_runner(tmp_path: Path) -> tuple[SyncRunner, MagicMock, MagicMock, MagicMock]:
+    """Return (runner, mock_db, mock_store, mock_session).
+
+    Configures the client to report a replica set and exposes the session
+    that will be bound inside ``with client.start_session() as session:``.
+    """
+    runner, db, store = _sync_runner(tmp_path)
+    runner._client.admin.command.return_value = {"setName": "rs0"}
+    mock_session = runner._client.start_session.return_value.__enter__.return_value
+    return runner, db, store, mock_session
+
+
+def test_sync_up_transactional_injects_session_into_migration(tmp_path: Path) -> None:
+    runner, db, store, mock_session = _transactional_runner(tmp_path)
+
+    def up_fn(received_db: Any) -> None:
+        received_db["col"].insert_one({"x": 1})
+
+    mod = types.ModuleType("_test_txn_up")
+    setattr(mod, "up", up_fn)
+    migration = MigrationFile(id="001_a", path=Path("001_a.py"), checksum="abc", module=mod)
+    store.get_applied.return_value = set()
+
+    with patch("mongrator.runner.loader.load", return_value=[migration]):
+        runner.up(transactional=True)
+
+    db["col"].insert_one.assert_called_once_with({"x": 1}, session=mock_session)
+
+
+def test_sync_up_transactional_injects_session_into_ops(tmp_path: Path) -> None:
+    runner, db, store, mock_session = _transactional_runner(tmp_path)
+    migrations = [_migration("001_a", ops_based=True)]  # create_index op
+    store.get_applied.return_value = set()
+
+    with patch("mongrator.runner.loader.load", return_value=migrations):
+        runner.up(transactional=True)
+
+    _, call_kwargs = db["col"].create_index.call_args
+    assert call_kwargs.get("session") is mock_session
+
+
+def test_sync_down_transactional_injects_session_into_migration(tmp_path: Path) -> None:
+    runner, db, store, mock_session = _transactional_runner(tmp_path)
+
+    def down_fn(received_db: Any) -> None:
+        received_db["col"].delete_many({})
+
+    mod = types.ModuleType("_test_txn_down")
+    setattr(mod, "up", lambda d: None)
+    setattr(mod, "down", down_fn)
+    migration = MigrationFile(id="001_a", path=Path("001_a.py"), checksum="abc", module=mod)
+    store.get_applied.return_value = {"001_a"}
+
+    with patch("mongrator.runner.loader.load", return_value=[migration]):
+        runner.down(transactional=True)
+
+    db["col"].delete_many.assert_called_once_with({}, session=mock_session)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -142,8 +142,8 @@ def _transactional_runner(tmp_path: Path) -> tuple[SyncRunner, MagicMock, MagicM
     that will be bound inside ``with client.start_session() as session:``.
     """
     runner, db, store = _sync_runner(tmp_path)
-    runner._client.admin.command.return_value = {"setName": "rs0"}
-    mock_session = runner._client.start_session.return_value.__enter__.return_value
+    runner._client.admin.command.return_value = {"setName": "rs0"}  # ty: ignore[unresolved-attribute]
+    mock_session = runner._client.start_session.return_value.__enter__.return_value  # ty: ignore[unresolved-attribute]
     return runner, db, store, mock_session
 
 


### PR DESCRIPTION
💁 These changes add a `--transactional` flag to the `up` and `down` CLI commands. When enabled, each migration runs inside a MongoDB transaction, providing automatic rollback on failure. Requires a replica set — a clear `TransactionNotSupportedError` is raised for standalone servers. The flag is opt-in with no change to default behavior.