### PR TITLE
refactor(cli): migrate from argparse to click

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ classifiers = [
   "Typing :: Typed",
 ]
 dependencies = [
+  "click>=8",
   "pymongo>=4.10",
 ]
 

--- a/src/mongrator/cli.py
+++ b/src/mongrator/cli.py
@@ -16,13 +16,13 @@ Exit codes:
     130 — interrupted (KeyboardInterrupt / Ctrl-C)
 """
 
-import argparse
 import asyncio
 import sys
 from datetime import UTC, datetime
 from importlib.resources import files
 from pathlib import Path
 
+import click
 import pymongo
 from pymongo import AsyncMongoClient
 
@@ -31,76 +31,26 @@ from .exceptions import MigratorError
 from .planner import MigrationPlan
 
 #: Exit code returned when there are no migrations to apply or roll back.
-#: Deliberately avoids ``2``, which argparse uses for CLI usage errors.
+#: Deliberately avoids ``2``, which click uses for CLI usage errors.
 EXIT_NOTHING_TO_DO = 4
 
 
-def _positive_int(value: str) -> int:
-    """Argparse type that accepts only positive integers (>= 1)."""
-    try:
-        n = int(value)
-    except ValueError:
-        raise argparse.ArgumentTypeError(f"invalid int value: '{value}'")
-    if n < 1:
-        raise argparse.ArgumentTypeError(f"steps must be >= 1, got {n}")
-    return n
+class _PositiveInt(click.ParamType):
+    """Click parameter type that accepts only positive integers (>= 1)."""
+
+    name = "positive_int"
+
+    def convert(self, value: str, param: click.Parameter | None, ctx: click.Context | None) -> int:
+        try:
+            n = int(value)
+        except (ValueError, TypeError):
+            self.fail(f"invalid int value: '{value}'", param, ctx)
+        if n < 1:
+            self.fail(f"steps must be >= 1, got {n}", param, ctx)
+        return n
 
 
-def _build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(
-        prog="mongrator",
-        description="Lightweight MongoDB schema migration tool",
-    )
-    parser.add_argument(
-        "--config",
-        metavar="PATH",
-        default="mongrator.toml",
-        help="path to config file (default: mongrator.toml)",
-    )
-
-    sub = parser.add_subparsers(dest="command", metavar="COMMAND")
-    sub.required = True
-
-    # init
-    sub.add_parser("init", help="create migrations directory and config stub")
-
-    # create
-    p_create = sub.add_parser("create", help="generate a new migration file")
-    p_create.add_argument("name", help="short description, e.g. add_users_email_index")
-
-    # status
-    sub.add_parser("status", help="show applied/pending migration table")
-
-    # up
-    p_up = sub.add_parser("up", help="apply pending migrations")
-    p_up.add_argument("--target", metavar="ID", help="apply only up to this migration ID")
-    p_up.add_argument("--async", dest="use_async", action="store_true", help="use async runner")
-    p_up.add_argument("--dry-run", action="store_true", help="show which migrations would be applied without executing")
-    p_up.add_argument(
-        "--transactional",
-        action="store_true",
-        help="wrap each migration in a MongoDB transaction (requires replica set)",
-    )
-
-    # down
-    p_down = sub.add_parser("down", help="roll back applied migrations")
-    p_down.add_argument(
-        "--steps", type=_positive_int, default=1, metavar="N", help="number of migrations to roll back (default: 1)"
-    )
-    p_down.add_argument("--async", dest="use_async", action="store_true", help="use async runner")
-    p_down.add_argument(
-        "--dry-run", action="store_true", help="show which migrations would be rolled back without executing"
-    )
-    p_down.add_argument(
-        "--transactional",
-        action="store_true",
-        help="wrap each migration in a MongoDB transaction (requires replica set)",
-    )
-
-    # validate
-    sub.add_parser("validate", help="verify checksums of applied migration files")
-
-    return parser
+POSITIVE_INT = _PositiveInt()
 
 
 def _print_dry_run(plan: MigrationPlan, *, direction: str) -> None:
@@ -118,20 +68,36 @@ def _print_dry_run(plan: MigrationPlan, *, direction: str) -> None:
         header = "Migrations that would be rolled back:"
 
     if not plan.to_apply:
-        print(empty_msg)
+        click.echo(empty_msg)
         return
 
-    print(header)
+    click.echo(header)
     for m in plan.to_apply:
-        print(f"  {action}  {m.id}")
+        click.echo(f"  {action}  {m.id}")
 
 
-def _load_config(args: argparse.Namespace) -> MigratorConfig:
-    config_path = Path(args.config)
-    if config_path.exists():
-        return MigratorConfig.from_toml(config_path)
+def _load_config(config_path: str) -> MigratorConfig:
+    path = Path(config_path)
+    if path.exists():
+        return MigratorConfig.from_toml(path)
     dotenv_path = Path(".env")
     return MigratorConfig.from_env(dotenv_path=dotenv_path if dotenv_path.is_file() else None)
+
+
+# ---------------------------------------------------------------------------
+# CLI group
+# ---------------------------------------------------------------------------
+
+
+@click.group(context_settings={"help_option_names": ["-h", "--help"]})
+@click.option("--config", "config_path", default="mongrator.toml", metavar="PATH", help="Path to config file.")
+@click.pass_context
+def cli(ctx: click.Context, config_path: str) -> None:
+    """Lightweight MongoDB schema migration tool."""
+    ctx.ensure_object(dict)
+    ctx.obj["config_path"] = config_path
+    if ctx.invoked_subcommand is None:
+        raise click.UsageError("Missing command.", ctx=ctx)
 
 
 # ---------------------------------------------------------------------------
@@ -139,26 +105,32 @@ def _load_config(args: argparse.Namespace) -> MigratorConfig:
 # ---------------------------------------------------------------------------
 
 
-def _cmd_init(args: argparse.Namespace) -> int:
-    config_path = Path(args.config)
+@cli.command()
+@click.pass_context
+def init(ctx: click.Context) -> None:
+    """Create migrations directory and config stub."""
+    config_path = Path(ctx.obj["config_path"])
     if not config_path.exists():
         config_path.write_text(
             '[mongrator]\nuri = "mongodb://localhost:27017"\ndatabase = "mydb"\n'
             'migrations_dir = "migrations"\ncollection = "mongrator_migrations"\n'
         )
-        print(f"Created {config_path}")
+        click.echo(f"Created {config_path}")
 
     migrations_dir = Path("migrations")
     migrations_dir.mkdir(exist_ok=True)
-    print(f"Created {migrations_dir}/")
-    return 0
+    click.echo(f"Created {migrations_dir}/")
 
 
-def _cmd_create(args: argparse.Namespace) -> int:
-    config = _load_config(args)
+@cli.command()
+@click.argument("name")
+@click.pass_context
+def create(ctx: click.Context, name: str) -> None:
+    """Generate a new migration file."""
+    config = _load_config(ctx.obj["config_path"])
     config.migrations_dir.mkdir(parents=True, exist_ok=True)
 
-    slug = args.name.strip().replace(" ", "_").lower()
+    slug = name.strip().replace(" ", "_").lower()
     timestamp = datetime.now(tz=UTC).strftime("%Y%m%d_%H%M%S")
     filename = f"{timestamp}_{slug}.py"
     dest = config.migrations_dir / filename
@@ -166,25 +138,27 @@ def _cmd_create(args: argparse.Namespace) -> int:
     template_text = files("mongrator._templates").joinpath("migration.py.tmpl").read_text(encoding="utf-8")
     content = template_text.format(slug=slug, timestamp=timestamp)
     dest.write_text(content, encoding="utf-8")
-    print(f"Created {dest}")
-    return 0
+    click.echo(f"Created {dest}")
 
 
-def _cmd_status(args: argparse.Namespace) -> int:
+@cli.command()
+@click.pass_context
+def status(ctx: click.Context) -> None:
+    """Show applied/pending migration table."""
     from .runner import SyncRunner
 
-    config = _load_config(args)
+    config = _load_config(ctx.obj["config_path"])
     with pymongo.MongoClient(config.uri) as client:
         runner = SyncRunner(client, config)
         statuses = runner.status()
 
     if not statuses:
-        print("No migrations found.")
-        return 0
+        click.echo("No migrations found.")
+        return
 
     col_width = max(len(s.id) for s in statuses) + 2
-    print(f"{'Migration':<{col_width}} {'Status':<10} {'Applied At'}")
-    print("-" * (col_width + 30))
+    click.echo(f"{'Migration':<{col_width}} {'Status':<10} {'Applied At'}")
+    click.echo("-" * (col_width + 30))
     for s in statuses:
         if s.orphaned:
             state = "ORPHANED"
@@ -195,29 +169,43 @@ def _cmd_status(args: argparse.Namespace) -> int:
         else:
             state = "pending"
         applied_at = s.applied_at.isoformat() if s.applied_at else "-"
-        print(f"{s.id:<{col_width}} {state:<10} {applied_at}")
-    return 0
+        click.echo(f"{s.id:<{col_width}} {state:<10} {applied_at}")
 
 
-def _cmd_up(args: argparse.Namespace) -> int:
-    config = _load_config(args)
-    if args.use_async:
-        return asyncio.run(_async_up(config, args.target, dry_run=args.dry_run, transactional=args.transactional))
+@cli.command()
+@click.option("--target", metavar="ID", default=None, help="Apply only up to this migration ID.")
+@click.option("--async", "use_async", is_flag=True, default=False, help="Use async runner.")
+@click.option("--dry-run", is_flag=True, default=False, help="Show migrations that would be applied.")
+@click.option(
+    "--transactional",
+    is_flag=True,
+    default=False,
+    help="Wrap each migration in a MongoDB transaction (requires replica set).",
+)
+@click.pass_context
+def up(ctx: click.Context, target: str | None, use_async: bool, dry_run: bool, transactional: bool) -> None:
+    """Apply pending migrations."""
+    config = _load_config(ctx.obj["config_path"])
+    if use_async:
+        rc = asyncio.run(_async_up(config, target, dry_run=dry_run, transactional=transactional))
+        ctx.exit(rc)
+        return
     from .runner import SyncRunner
 
     with pymongo.MongoClient(config.uri) as client:
         runner = SyncRunner(client, config)
-        if args.dry_run:
-            plan = runner.plan_up(target=args.target)
+        if dry_run:
+            plan = runner.plan_up(target=target)
             _print_dry_run(plan, direction="up")
-            return EXIT_NOTHING_TO_DO if not plan.to_apply else 0
-        applied = runner.up(target=args.target, transactional=args.transactional)
+            ctx.exit(EXIT_NOTHING_TO_DO if not plan.to_apply else 0)
+            return
+        applied = runner.up(target=target, transactional=transactional)
     if applied:
         for mid in applied:
-            print(f"  applied  {mid}")
-        return 0
-    print("Nothing to apply.")
-    return EXIT_NOTHING_TO_DO
+            click.echo(f"  applied  {mid}")
+        return
+    click.echo("Nothing to apply.")
+    ctx.exit(EXIT_NOTHING_TO_DO)
 
 
 async def _async_up(
@@ -239,31 +227,46 @@ async def _async_up(
             applied = await runner.up(target=target, transactional=transactional)
     if applied:
         for mid in applied:
-            print(f"  applied  {mid}")
+            click.echo(f"  applied  {mid}")
         return 0
-    print("Nothing to apply.")
+    click.echo("Nothing to apply.")
     return EXIT_NOTHING_TO_DO
 
 
-def _cmd_down(args: argparse.Namespace) -> int:
-    config = _load_config(args)
-    if args.use_async:
-        return asyncio.run(_async_down(config, args.steps, dry_run=args.dry_run, transactional=args.transactional))
+@cli.command()
+@click.option("--steps", type=POSITIVE_INT, default=1, metavar="N", help="Number of migrations to roll back.")
+@click.option("--async", "use_async", is_flag=True, default=False, help="Use async runner.")
+@click.option("--dry-run", is_flag=True, default=False, help="Show migrations that would be rolled back.")
+@click.option(
+    "--transactional",
+    is_flag=True,
+    default=False,
+    help="Wrap each migration in a MongoDB transaction (requires replica set).",
+)
+@click.pass_context
+def down(ctx: click.Context, steps: int, use_async: bool, dry_run: bool, transactional: bool) -> None:
+    """Roll back applied migrations."""
+    config = _load_config(ctx.obj["config_path"])
+    if use_async:
+        rc = asyncio.run(_async_down(config, steps, dry_run=dry_run, transactional=transactional))
+        ctx.exit(rc)
+        return
     from .runner import SyncRunner
 
     with pymongo.MongoClient(config.uri) as client:
         runner = SyncRunner(client, config)
-        if args.dry_run:
-            plan = runner.plan_down(steps=args.steps)
+        if dry_run:
+            plan = runner.plan_down(steps=steps)
             _print_dry_run(plan, direction="down")
-            return EXIT_NOTHING_TO_DO if not plan.to_apply else 0
-        rolled_back = runner.down(steps=args.steps, transactional=args.transactional)
+            ctx.exit(EXIT_NOTHING_TO_DO if not plan.to_apply else 0)
+            return
+        rolled_back = runner.down(steps=steps, transactional=transactional)
     if rolled_back:
         for mid in rolled_back:
-            print(f"  rolled back  {mid}")
-        return 0
-    print("Nothing to roll back.")
-    return EXIT_NOTHING_TO_DO
+            click.echo(f"  rolled back  {mid}")
+        return
+    click.echo("Nothing to roll back.")
+    ctx.exit(EXIT_NOTHING_TO_DO)
 
 
 async def _async_down(
@@ -285,29 +288,32 @@ async def _async_down(
             rolled_back = await runner.down(steps=steps, transactional=transactional)
     if rolled_back:
         for mid in rolled_back:
-            print(f"  rolled back  {mid}")
+            click.echo(f"  rolled back  {mid}")
         return 0
-    print("Nothing to roll back.")
+    click.echo("Nothing to roll back.")
     return EXIT_NOTHING_TO_DO
 
 
-def _cmd_validate(args: argparse.Namespace) -> int:
+@cli.command()
+@click.pass_context
+def validate(ctx: click.Context) -> None:
+    """Verify checksums of applied migration files."""
     from .runner import SyncRunner
 
-    config = _load_config(args)
+    config = _load_config(ctx.obj["config_path"])
     with pymongo.MongoClient(config.uri) as client:
         runner = SyncRunner(client, config)
         errors = runner.validate()
 
     if not errors:
-        print("All applied migrations have valid checksums.")
-        return 0
+        click.echo("All applied migrations have valid checksums.")
+        return
 
     eg = ExceptionGroup("Checksum mismatches detected", errors)
-    print(f"error: {eg}", file=sys.stderr)
+    click.echo(f"error: {eg}", err=True)
     for e in errors:
-        print(f"  {e}", file=sys.stderr)
-    return 1
+        click.echo(f"  {e}", err=True)
+    ctx.exit(1)
 
 
 # ---------------------------------------------------------------------------
@@ -316,24 +322,21 @@ def _cmd_validate(args: argparse.Namespace) -> int:
 
 
 def main() -> None:
-    parser = _build_parser()
-    args = parser.parse_args()
-
-    dispatch = {
-        "init": _cmd_init,
-        "create": _cmd_create,
-        "status": _cmd_status,
-        "up": _cmd_up,
-        "down": _cmd_down,
-        "validate": _cmd_validate,
-    }
-
     try:
-        rc = dispatch[args.command](args)
+        cli(standalone_mode=False)
+    except click.exceptions.Abort:
+        sys.exit(130)
+    except click.exceptions.Exit as e:
+        sys.exit(e.exit_code)
+    except click.exceptions.UsageError as e:
+        if e.ctx:
+            click.echo(e.ctx.command.get_usage(e.ctx), err=True)
+        click.echo(f"error: {e.format_message()}", err=True)
+        sys.exit(2)
     except MigratorError as e:
-        print(f"error: {e}", file=sys.stderr)
+        click.echo(f"error: {e}", err=True)
         sys.exit(1)
     except KeyboardInterrupt:
         sys.exit(130)
-
-    sys.exit(rc)
+    else:
+        sys.exit(0)

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,21 +1,16 @@
-"""Unit tests for mongrator.cli — argument parsing and command handlers."""
+"""Unit tests for mongrator.cli — click-based CLI commands."""
 
 from datetime import UTC, datetime
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from click.testing import CliRunner
 
 from mongrator.cli import (
     EXIT_NOTHING_TO_DO,
-    _build_parser,
-    _cmd_create,
-    _cmd_down,
-    _cmd_init,
-    _cmd_status,
-    _cmd_up,
-    _cmd_validate,
     _load_config,
+    cli,
     main,
 )
 from mongrator.exceptions import ChecksumMismatchError, MigratorError
@@ -25,14 +20,7 @@ from mongrator.migration import MigrationStatus
 # Helpers
 # ---------------------------------------------------------------------------
 
-
-def parse(*args: str):
-    return _build_parser().parse_args(args)
-
-
-def parse_fails(*args: str) -> None:
-    with pytest.raises(SystemExit):
-        _build_parser().parse_args(args)
+runner = CliRunner()
 
 
 # ---------------------------------------------------------------------------
@@ -41,17 +29,26 @@ def parse_fails(*args: str) -> None:
 
 
 def test_default_config() -> None:
-    ns = parse("init")
-    assert ns.config == "mongrator.toml"
+    """Init with default config path creates mongrator.toml and migrations/."""
+    with runner.isolated_filesystem() as td:
+        result = runner.invoke(cli, ["init"], catch_exceptions=False)
+        assert result.exit_code == 0
+        assert (Path(td) / "mongrator.toml").exists()
+        assert (Path(td) / "migrations").is_dir()
 
 
-def test_custom_config() -> None:
-    ns = parse("--config", "custom.toml", "init")
-    assert ns.config == "custom.toml"
+def test_custom_config(tmp_path: Path) -> None:
+    """Custom --config option is passed through to subcommands."""
+    config_file = tmp_path / "custom.toml"
+    mdir = (tmp_path / "migrations").as_posix()
+    config_file.write_text(f'[mongrator]\nuri = "mongodb://localhost"\ndatabase = "db"\nmigrations_dir = \'{mdir}\'\n')
+    result = runner.invoke(cli, ["--config", str(config_file), "create", "test_migration"])
+    assert result.exit_code == 0
 
 
-def test_missing_command_exits() -> None:
-    parse_fails()
+def test_missing_command_exits_with_usage_error() -> None:
+    result = runner.invoke(cli, [])
+    assert result.exit_code == 2
 
 
 # ---------------------------------------------------------------------------
@@ -60,8 +57,9 @@ def test_missing_command_exits() -> None:
 
 
 def test_init_command() -> None:
-    ns = parse("init")
-    assert ns.command == "init"
+    with runner.isolated_filesystem():
+        result = runner.invoke(cli, ["init"])
+    assert result.exit_code == 0
 
 
 # ---------------------------------------------------------------------------
@@ -69,14 +67,22 @@ def test_init_command() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_create_command_with_name() -> None:
-    ns = parse("create", "add_users_email_index")
-    assert ns.command == "create"
-    assert ns.name == "add_users_email_index"
+def test_create_command_with_name(tmp_path: Path) -> None:
+    config_file = tmp_path / "mongrator.toml"
+    migrations_dir = tmp_path / "migrations"
+    config_file.write_text(
+        f'[mongrator]\nuri = "mongodb://localhost"\ndatabase = "db"\nmigrations_dir = \'{migrations_dir.as_posix()}\'\n'
+    )
+    result = runner.invoke(cli, ["--config", str(config_file), "create", "add_users_email_index"])
+    assert result.exit_code == 0
+    files = list(migrations_dir.glob("*.py"))
+    assert len(files) == 1
+    assert "add_users_email_index" in files[0].name
 
 
 def test_create_missing_name_exits() -> None:
-    parse_fails("create")
+    result = runner.invoke(cli, ["create"])
+    assert result.exit_code != 0
 
 
 # ---------------------------------------------------------------------------
@@ -85,8 +91,15 @@ def test_create_missing_name_exits() -> None:
 
 
 def test_status_command() -> None:
-    ns = parse("status")
-    assert ns.command == "status"
+    mock_run = MagicMock()
+    mock_run.status.return_value = []
+    with (
+        patch("mongrator.cli._load_config"),
+        patch("pymongo.MongoClient", return_value=MagicMock()),
+        patch("mongrator.runner.SyncRunner", return_value=mock_run),
+    ):
+        result = runner.invoke(cli, ["status"])
+    assert result.exit_code == 0
 
 
 # ---------------------------------------------------------------------------
@@ -95,46 +108,78 @@ def test_status_command() -> None:
 
 
 def test_up_defaults() -> None:
-    ns = parse("up")
-    assert ns.command == "up"
-    assert ns.target is None
-    assert ns.use_async is False
+    mock_run = MagicMock()
+    mock_run.up.return_value = []
+    with (
+        patch("mongrator.cli._load_config"),
+        patch("pymongo.MongoClient", return_value=MagicMock()),
+        patch("mongrator.runner.SyncRunner", return_value=mock_run),
+    ):
+        result = runner.invoke(cli, ["up"])
+    assert result.exit_code == EXIT_NOTHING_TO_DO
+    assert "Nothing to apply" in result.output
 
 
 def test_up_with_target() -> None:
-    ns = parse("up", "--target", "002_b")
-    assert ns.target == "002_b"
+    mock_run = MagicMock()
+    mock_run.up.return_value = ["002_b"]
+    with (
+        patch("mongrator.cli._load_config"),
+        patch("pymongo.MongoClient", return_value=MagicMock()),
+        patch("mongrator.runner.SyncRunner", return_value=mock_run),
+    ):
+        result = runner.invoke(cli, ["up", "--target", "002_b"])
+    assert result.exit_code == 0
+    mock_run.up.assert_called_once_with(target="002_b", transactional=False)
 
 
 def test_up_async_flag() -> None:
-    ns = parse("up", "--async")
-    assert ns.use_async is True
-
-
-def test_up_target_and_async() -> None:
-    ns = parse("up", "--target", "002_b", "--async")
-    assert ns.target == "002_b"
-    assert ns.use_async is True
+    """--async flag is accepted on the up subcommand."""
+    with (
+        patch("mongrator.cli._load_config"),
+        patch("mongrator.cli._async_up", new_callable=AsyncMock, return_value=0) as mock_async_up,
+    ):
+        result = runner.invoke(cli, ["up", "--async"])
+    assert result.exit_code == 0
+    mock_async_up.assert_awaited_once()
 
 
 def test_up_dry_run_flag() -> None:
-    ns = parse("up", "--dry-run")
-    assert ns.dry_run is True
-
-
-def test_up_dry_run_default() -> None:
-    ns = parse("up")
-    assert ns.dry_run is False
-
-
-def test_up_transactional_default() -> None:
-    ns = parse("up")
-    assert ns.transactional is False
+    mock_run = MagicMock()
+    plan = MagicMock()
+    plan.to_apply = []
+    mock_run.plan_up.return_value = plan
+    with (
+        patch("mongrator.cli._load_config"),
+        patch("pymongo.MongoClient", return_value=MagicMock()),
+        patch("mongrator.runner.SyncRunner", return_value=mock_run),
+    ):
+        runner.invoke(cli, ["up", "--dry-run"])
+    mock_run.plan_up.assert_called_once()
 
 
 def test_up_transactional_flag() -> None:
-    ns = parse("up", "--transactional")
-    assert ns.transactional is True
+    mock_run = MagicMock()
+    mock_run.up.return_value = []
+    with (
+        patch("mongrator.cli._load_config"),
+        patch("pymongo.MongoClient", return_value=MagicMock()),
+        patch("mongrator.runner.SyncRunner", return_value=mock_run),
+    ):
+        runner.invoke(cli, ["up", "--transactional"])
+    mock_run.up.assert_called_once_with(target=None, transactional=True)
+
+
+def test_up_transactional_default() -> None:
+    mock_run = MagicMock()
+    mock_run.up.return_value = []
+    with (
+        patch("mongrator.cli._load_config"),
+        patch("pymongo.MongoClient", return_value=MagicMock()),
+        patch("mongrator.runner.SyncRunner", return_value=mock_run),
+    ):
+        runner.invoke(cli, ["up"])
+    mock_run.up.assert_called_once_with(target=None, transactional=False)
 
 
 # ---------------------------------------------------------------------------
@@ -143,52 +188,92 @@ def test_up_transactional_flag() -> None:
 
 
 def test_down_defaults() -> None:
-    ns = parse("down")
-    assert ns.command == "down"
-    assert ns.steps == 1
-    assert ns.use_async is False
+    mock_run = MagicMock()
+    mock_run.down.return_value = []
+    with (
+        patch("mongrator.cli._load_config"),
+        patch("pymongo.MongoClient", return_value=MagicMock()),
+        patch("mongrator.runner.SyncRunner", return_value=mock_run),
+    ):
+        result = runner.invoke(cli, ["down"])
+    assert result.exit_code == EXIT_NOTHING_TO_DO
+    mock_run.down.assert_called_once_with(steps=1, transactional=False)
 
 
 def test_down_steps() -> None:
-    ns = parse("down", "--steps", "3")
-    assert ns.steps == 3
+    mock_run = MagicMock()
+    mock_run.down.return_value = ["003_c", "002_b", "001_a"]
+    with (
+        patch("mongrator.cli._load_config"),
+        patch("pymongo.MongoClient", return_value=MagicMock()),
+        patch("mongrator.runner.SyncRunner", return_value=mock_run),
+    ):
+        result = runner.invoke(cli, ["down", "--steps", "3"])
+    assert result.exit_code == 0
+    mock_run.down.assert_called_once_with(steps=3, transactional=False)
 
 
 def test_down_async_flag() -> None:
-    ns = parse("down", "--async")
-    assert ns.use_async is True
+    with (
+        patch("mongrator.cli._load_config"),
+        patch("mongrator.cli._async_down", new_callable=AsyncMock, return_value=0) as mock_async_down,
+    ):
+        result = runner.invoke(cli, ["down", "--async"])
+    assert result.exit_code == 0
+    mock_async_down.assert_awaited_once()
 
 
 def test_down_dry_run_flag() -> None:
-    ns = parse("down", "--dry-run")
-    assert ns.dry_run is True
-
-
-def test_down_dry_run_default() -> None:
-    ns = parse("down")
-    assert ns.dry_run is False
-
-
-def test_down_transactional_default() -> None:
-    ns = parse("down")
-    assert ns.transactional is False
+    mock_run = MagicMock()
+    plan = MagicMock()
+    plan.to_apply = []
+    mock_run.plan_down.return_value = plan
+    with (
+        patch("mongrator.cli._load_config"),
+        patch("pymongo.MongoClient", return_value=MagicMock()),
+        patch("mongrator.runner.SyncRunner", return_value=mock_run),
+    ):
+        runner.invoke(cli, ["down", "--dry-run"])
+    mock_run.plan_down.assert_called_once()
 
 
 def test_down_transactional_flag() -> None:
-    ns = parse("down", "--transactional")
-    assert ns.transactional is True
+    mock_run = MagicMock()
+    mock_run.down.return_value = []
+    with (
+        patch("mongrator.cli._load_config"),
+        patch("pymongo.MongoClient", return_value=MagicMock()),
+        patch("mongrator.runner.SyncRunner", return_value=mock_run),
+    ):
+        runner.invoke(cli, ["down", "--transactional"])
+    mock_run.down.assert_called_once_with(steps=1, transactional=True)
+
+
+def test_down_transactional_default() -> None:
+    mock_run = MagicMock()
+    mock_run.down.return_value = []
+    with (
+        patch("mongrator.cli._load_config"),
+        patch("pymongo.MongoClient", return_value=MagicMock()),
+        patch("mongrator.runner.SyncRunner", return_value=mock_run),
+    ):
+        runner.invoke(cli, ["down"])
+    mock_run.down.assert_called_once_with(steps=1, transactional=False)
 
 
 def test_down_invalid_steps_type_exits() -> None:
-    parse_fails("down", "--steps", "not_a_number")
+    result = runner.invoke(cli, ["down", "--steps", "not_a_number"])
+    assert result.exit_code != 0
 
 
 def test_down_zero_steps_exits() -> None:
-    parse_fails("down", "--steps", "0")
+    result = runner.invoke(cli, ["down", "--steps", "0"])
+    assert result.exit_code != 0
 
 
 def test_down_negative_steps_exits() -> None:
-    parse_fails("down", "--steps", "-1")
+    result = runner.invoke(cli, ["down", "--steps", "-1"])
+    assert result.exit_code != 0
 
 
 # ---------------------------------------------------------------------------
@@ -197,8 +282,15 @@ def test_down_negative_steps_exits() -> None:
 
 
 def test_validate_command() -> None:
-    ns = parse("validate")
-    assert ns.command == "validate"
+    mock_run = MagicMock()
+    mock_run.validate.return_value = []
+    with (
+        patch("mongrator.cli._load_config"),
+        patch("pymongo.MongoClient", return_value=MagicMock()),
+        patch("mongrator.runner.SyncRunner", return_value=mock_run),
+    ):
+        result = runner.invoke(cli, ["validate"])
+    assert result.exit_code == 0
 
 
 # ---------------------------------------------------------------------------
@@ -209,16 +301,14 @@ def test_validate_command() -> None:
 def test_load_config_from_toml(tmp_path: Path) -> None:
     config_file = tmp_path / "mongrator.toml"
     config_file.write_text('[mongrator]\nuri = "mongodb://localhost:27017"\ndatabase = "testdb"\n')
-    ns = parse("--config", str(config_file), "init")
-    config = _load_config(ns)
+    config = _load_config(str(config_file))
     assert config.database == "testdb"
 
 
 def test_load_config_from_env_when_file_missing(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("MONGRATOR_URI", "mongodb://localhost:27017")
     monkeypatch.setenv("MONGRATOR_DB", "envdb")
-    ns = parse("--config", "nonexistent.toml", "init")
-    config = _load_config(ns)
+    config = _load_config("nonexistent.toml")
     assert config.database == "envdb"
 
 
@@ -229,9 +319,8 @@ def test_load_config_from_env_when_file_missing(monkeypatch: pytest.MonkeyPatch)
 
 def test_cmd_init_creates_config_and_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.chdir(tmp_path)
-    ns = parse("init")
-    rc = _cmd_init(ns)
-    assert rc == 0
+    result = runner.invoke(cli, ["--config", str(tmp_path / "mongrator.toml"), "init"])
+    assert result.exit_code == 0
     assert (tmp_path / "mongrator.toml").exists()
     assert (tmp_path / "migrations").is_dir()
 
@@ -240,8 +329,7 @@ def test_cmd_init_does_not_overwrite_config(tmp_path: Path, monkeypatch: pytest.
     monkeypatch.chdir(tmp_path)
     config_file = tmp_path / "mongrator.toml"
     config_file.write_text("existing content")
-    ns = parse("init")
-    _cmd_init(ns)
+    runner.invoke(cli, ["--config", str(config_file), "init"])
     assert config_file.read_text() == "existing content"
 
 
@@ -256,12 +344,11 @@ def test_cmd_create_generates_migration_file(tmp_path: Path) -> None:
     config_file.write_text(
         f'[mongrator]\nuri = "mongodb://localhost"\ndatabase = "db"\nmigrations_dir = \'{migrations_dir.as_posix()}\'\n'
     )
-    ns = parse("--config", str(config_file), "create", "add_users_index")
-    rc = _cmd_create(ns)
-    assert rc == 0
-    files = list(migrations_dir.glob("*.py"))
-    assert len(files) == 1
-    assert "add_users_index" in files[0].name
+    result = runner.invoke(cli, ["--config", str(config_file), "create", "add_users_index"])
+    assert result.exit_code == 0
+    created_files = list(migrations_dir.glob("*.py"))
+    assert len(created_files) == 1
+    assert "add_users_index" in created_files[0].name
 
 
 # ---------------------------------------------------------------------------
@@ -269,59 +356,54 @@ def test_cmd_create_generates_migration_file(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_cmd_status_no_migrations(capsys: pytest.CaptureFixture[str]) -> None:
-    mock_runner = MagicMock()
-    mock_runner.status.return_value = []
+def test_cmd_status_no_migrations() -> None:
+    mock_run = MagicMock()
+    mock_run.status.return_value = []
     with (
         patch("mongrator.cli._load_config"),
         patch("pymongo.MongoClient", return_value=MagicMock()),
-        patch("mongrator.runner.SyncRunner", return_value=mock_runner),
+        patch("mongrator.runner.SyncRunner", return_value=mock_run),
     ):
-        ns = parse("status")
-        rc = _cmd_status(ns)
-    assert rc == 0
-    assert "No migrations found" in capsys.readouterr().out
+        result = runner.invoke(cli, ["status"])
+    assert result.exit_code == 0
+    assert "No migrations found" in result.output
 
 
-def test_cmd_status_shows_applied_and_pending(capsys: pytest.CaptureFixture[str]) -> None:
+def test_cmd_status_shows_applied_and_pending() -> None:
     statuses = [
         MigrationStatus(id="001_a", applied=True, applied_at=datetime(2025, 1, 1, tzinfo=UTC)),
         MigrationStatus(id="002_b", applied=False),
     ]
-    mock_runner = MagicMock()
-    mock_runner.status.return_value = statuses
+    mock_run = MagicMock()
+    mock_run.status.return_value = statuses
     with (
         patch("mongrator.cli._load_config"),
         patch("pymongo.MongoClient", return_value=MagicMock()),
-        patch("mongrator.runner.SyncRunner", return_value=mock_runner),
+        patch("mongrator.runner.SyncRunner", return_value=mock_run),
     ):
-        ns = parse("status")
-        rc = _cmd_status(ns)
-    assert rc == 0
-    out = capsys.readouterr().out
-    assert "001_a" in out
-    assert "applied" in out
-    assert "pending" in out
+        result = runner.invoke(cli, ["status"])
+    assert result.exit_code == 0
+    assert "001_a" in result.output
+    assert "applied" in result.output
+    assert "pending" in result.output
 
 
-def test_cmd_status_shows_orphaned(capsys: pytest.CaptureFixture[str]) -> None:
+def test_cmd_status_shows_orphaned() -> None:
     statuses = [
         MigrationStatus(id="001_a", applied=True, applied_at=datetime(2025, 1, 1, tzinfo=UTC)),
         MigrationStatus(id="002_deleted", applied=True, applied_at=datetime(2025, 1, 2, tzinfo=UTC), orphaned=True),
     ]
-    mock_runner = MagicMock()
-    mock_runner.status.return_value = statuses
+    mock_run = MagicMock()
+    mock_run.status.return_value = statuses
     with (
         patch("mongrator.cli._load_config"),
         patch("pymongo.MongoClient", return_value=MagicMock()),
-        patch("mongrator.runner.SyncRunner", return_value=mock_runner),
+        patch("mongrator.runner.SyncRunner", return_value=mock_run),
     ):
-        ns = parse("status")
-        rc = _cmd_status(ns)
-    assert rc == 0
-    out = capsys.readouterr().out
-    assert "ORPHANED" in out
-    assert "002_deleted" in out
+        result = runner.invoke(cli, ["status"])
+    assert result.exit_code == 0
+    assert "ORPHANED" in result.output
+    assert "002_deleted" in result.output
 
 
 # ---------------------------------------------------------------------------
@@ -329,92 +411,85 @@ def test_cmd_status_shows_orphaned(capsys: pytest.CaptureFixture[str]) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_cmd_up_applies_migrations(capsys: pytest.CaptureFixture[str]) -> None:
-    mock_runner = MagicMock()
-    mock_runner.up.return_value = ["001_a", "002_b"]
+def test_cmd_up_applies_migrations() -> None:
+    mock_run = MagicMock()
+    mock_run.up.return_value = ["001_a", "002_b"]
     with (
         patch("mongrator.cli._load_config"),
         patch("pymongo.MongoClient", return_value=MagicMock()),
-        patch("mongrator.runner.SyncRunner", return_value=mock_runner),
+        patch("mongrator.runner.SyncRunner", return_value=mock_run),
     ):
-        ns = parse("up")
-        rc = _cmd_up(ns)
-    assert rc == 0
-    out = capsys.readouterr().out
-    assert "001_a" in out
-    assert "002_b" in out
+        result = runner.invoke(cli, ["up"])
+    assert result.exit_code == 0
+    assert "001_a" in result.output
+    assert "002_b" in result.output
 
 
-def test_cmd_up_nothing_to_apply(capsys: pytest.CaptureFixture[str]) -> None:
-    mock_runner = MagicMock()
-    mock_runner.up.return_value = []
+def test_cmd_up_nothing_to_apply() -> None:
+    mock_run = MagicMock()
+    mock_run.up.return_value = []
     with (
         patch("mongrator.cli._load_config"),
         patch("pymongo.MongoClient", return_value=MagicMock()),
-        patch("mongrator.runner.SyncRunner", return_value=mock_runner),
+        patch("mongrator.runner.SyncRunner", return_value=mock_run),
     ):
-        ns = parse("up")
-        rc = _cmd_up(ns)
-    assert rc == EXIT_NOTHING_TO_DO
-    assert "Nothing to apply" in capsys.readouterr().out
+        result = runner.invoke(cli, ["up"])
+    assert result.exit_code == EXIT_NOTHING_TO_DO
+    assert "Nothing to apply" in result.output
 
 
-def test_cmd_up_dry_run_with_pending(capsys: pytest.CaptureFixture[str]) -> None:
-    mock_runner = MagicMock()
+def test_cmd_up_dry_run_with_pending() -> None:
+    mock_run = MagicMock()
     mock_plan = MagicMock()
     mock_plan.to_apply = [MagicMock(id="001_a")]
-    mock_runner.plan_up.return_value = mock_plan
+    mock_run.plan_up.return_value = mock_plan
     with (
         patch("mongrator.cli._load_config"),
         patch("pymongo.MongoClient", return_value=MagicMock()),
-        patch("mongrator.runner.SyncRunner", return_value=mock_runner),
+        patch("mongrator.runner.SyncRunner", return_value=mock_run),
     ):
-        ns = parse("up", "--dry-run")
-        rc = _cmd_up(ns)
-    assert rc == 0
-    assert "001_a" in capsys.readouterr().out
+        result = runner.invoke(cli, ["up", "--dry-run"])
+    assert result.exit_code == 0
+    assert "001_a" in result.output
 
 
-def test_cmd_up_passes_transactional_false_by_default(capsys: pytest.CaptureFixture[str]) -> None:
-    mock_runner = MagicMock()
-    mock_runner.up.return_value = []
-    with (
-        patch("mongrator.cli._load_config"),
-        patch("pymongo.MongoClient", return_value=MagicMock()),
-        patch("mongrator.runner.SyncRunner", return_value=mock_runner),
-    ):
-        ns = parse("up")
-        _cmd_up(ns)
-    mock_runner.up.assert_called_once_with(target=None, transactional=False)
-
-
-def test_cmd_up_passes_transactional_true(capsys: pytest.CaptureFixture[str]) -> None:
-    mock_runner = MagicMock()
-    mock_runner.up.return_value = []
-    with (
-        patch("mongrator.cli._load_config"),
-        patch("pymongo.MongoClient", return_value=MagicMock()),
-        patch("mongrator.runner.SyncRunner", return_value=mock_runner),
-    ):
-        ns = parse("up", "--transactional")
-        _cmd_up(ns)
-    mock_runner.up.assert_called_once_with(target=None, transactional=True)
-
-
-def test_cmd_up_dry_run_nothing_to_apply(capsys: pytest.CaptureFixture[str]) -> None:
-    mock_runner = MagicMock()
+def test_cmd_up_dry_run_nothing_to_apply() -> None:
+    mock_run = MagicMock()
     mock_plan = MagicMock()
     mock_plan.to_apply = []
-    mock_runner.plan_up.return_value = mock_plan
+    mock_run.plan_up.return_value = mock_plan
     with (
         patch("mongrator.cli._load_config"),
         patch("pymongo.MongoClient", return_value=MagicMock()),
-        patch("mongrator.runner.SyncRunner", return_value=mock_runner),
+        patch("mongrator.runner.SyncRunner", return_value=mock_run),
     ):
-        ns = parse("up", "--dry-run")
-        rc = _cmd_up(ns)
-    assert rc == EXIT_NOTHING_TO_DO
-    assert "Nothing to apply" in capsys.readouterr().out
+        result = runner.invoke(cli, ["up", "--dry-run"])
+    assert result.exit_code == EXIT_NOTHING_TO_DO
+    assert "Nothing to apply" in result.output
+
+
+def test_cmd_up_passes_transactional_false_by_default() -> None:
+    mock_run = MagicMock()
+    mock_run.up.return_value = []
+    with (
+        patch("mongrator.cli._load_config"),
+        patch("pymongo.MongoClient", return_value=MagicMock()),
+        patch("mongrator.runner.SyncRunner", return_value=mock_run),
+    ):
+        runner.invoke(cli, ["up"])
+    mock_run.up.assert_called_once_with(target=None, transactional=False)
+
+
+def test_cmd_up_passes_transactional_true() -> None:
+    mock_run = MagicMock()
+    mock_run.up.return_value = []
+    with (
+        patch("mongrator.cli._load_config"),
+        patch("pymongo.MongoClient", return_value=MagicMock()),
+        patch("mongrator.runner.SyncRunner", return_value=mock_run),
+    ):
+        runner.invoke(cli, ["up", "--transactional"])
+    mock_run.up.assert_called_once_with(target=None, transactional=True)
 
 
 # ---------------------------------------------------------------------------
@@ -422,92 +497,85 @@ def test_cmd_up_dry_run_nothing_to_apply(capsys: pytest.CaptureFixture[str]) -> 
 # ---------------------------------------------------------------------------
 
 
-def test_cmd_down_rolls_back(capsys: pytest.CaptureFixture[str]) -> None:
-    mock_runner = MagicMock()
-    mock_runner.down.return_value = ["002_b"]
+def test_cmd_down_rolls_back() -> None:
+    mock_run = MagicMock()
+    mock_run.down.return_value = ["002_b"]
     with (
         patch("mongrator.cli._load_config"),
         patch("pymongo.MongoClient", return_value=MagicMock()),
-        patch("mongrator.runner.SyncRunner", return_value=mock_runner),
+        patch("mongrator.runner.SyncRunner", return_value=mock_run),
     ):
-        ns = parse("down")
-        rc = _cmd_down(ns)
-    assert rc == 0
-    out = capsys.readouterr().out
-    assert "002_b" in out
-    assert "rolled back" in out
+        result = runner.invoke(cli, ["down"])
+    assert result.exit_code == 0
+    assert "002_b" in result.output
+    assert "rolled back" in result.output
 
 
-def test_cmd_down_nothing_to_rollback(capsys: pytest.CaptureFixture[str]) -> None:
-    mock_runner = MagicMock()
-    mock_runner.down.return_value = []
+def test_cmd_down_nothing_to_rollback() -> None:
+    mock_run = MagicMock()
+    mock_run.down.return_value = []
     with (
         patch("mongrator.cli._load_config"),
         patch("pymongo.MongoClient", return_value=MagicMock()),
-        patch("mongrator.runner.SyncRunner", return_value=mock_runner),
+        patch("mongrator.runner.SyncRunner", return_value=mock_run),
     ):
-        ns = parse("down")
-        rc = _cmd_down(ns)
-    assert rc == EXIT_NOTHING_TO_DO
-    assert "Nothing to roll back" in capsys.readouterr().out
+        result = runner.invoke(cli, ["down"])
+    assert result.exit_code == EXIT_NOTHING_TO_DO
+    assert "Nothing to roll back" in result.output
 
 
-def test_cmd_down_dry_run_with_pending(capsys: pytest.CaptureFixture[str]) -> None:
-    mock_runner = MagicMock()
+def test_cmd_down_dry_run_with_pending() -> None:
+    mock_run = MagicMock()
     mock_plan = MagicMock()
     mock_plan.to_apply = [MagicMock(id="002_b")]
-    mock_runner.plan_down.return_value = mock_plan
+    mock_run.plan_down.return_value = mock_plan
     with (
         patch("mongrator.cli._load_config"),
         patch("pymongo.MongoClient", return_value=MagicMock()),
-        patch("mongrator.runner.SyncRunner", return_value=mock_runner),
+        patch("mongrator.runner.SyncRunner", return_value=mock_run),
     ):
-        ns = parse("down", "--dry-run")
-        rc = _cmd_down(ns)
-    assert rc == 0
-    assert "002_b" in capsys.readouterr().out
+        result = runner.invoke(cli, ["down", "--dry-run"])
+    assert result.exit_code == 0
+    assert "002_b" in result.output
 
 
-def test_cmd_down_passes_transactional_false_by_default(capsys: pytest.CaptureFixture[str]) -> None:
-    mock_runner = MagicMock()
-    mock_runner.down.return_value = []
-    with (
-        patch("mongrator.cli._load_config"),
-        patch("pymongo.MongoClient", return_value=MagicMock()),
-        patch("mongrator.runner.SyncRunner", return_value=mock_runner),
-    ):
-        ns = parse("down")
-        _cmd_down(ns)
-    mock_runner.down.assert_called_once_with(steps=1, transactional=False)
-
-
-def test_cmd_down_passes_transactional_true(capsys: pytest.CaptureFixture[str]) -> None:
-    mock_runner = MagicMock()
-    mock_runner.down.return_value = []
-    with (
-        patch("mongrator.cli._load_config"),
-        patch("pymongo.MongoClient", return_value=MagicMock()),
-        patch("mongrator.runner.SyncRunner", return_value=mock_runner),
-    ):
-        ns = parse("down", "--transactional")
-        _cmd_down(ns)
-    mock_runner.down.assert_called_once_with(steps=1, transactional=True)
-
-
-def test_cmd_down_dry_run_nothing_to_rollback(capsys: pytest.CaptureFixture[str]) -> None:
-    mock_runner = MagicMock()
+def test_cmd_down_dry_run_nothing_to_rollback() -> None:
+    mock_run = MagicMock()
     mock_plan = MagicMock()
     mock_plan.to_apply = []
-    mock_runner.plan_down.return_value = mock_plan
+    mock_run.plan_down.return_value = mock_plan
     with (
         patch("mongrator.cli._load_config"),
         patch("pymongo.MongoClient", return_value=MagicMock()),
-        patch("mongrator.runner.SyncRunner", return_value=mock_runner),
+        patch("mongrator.runner.SyncRunner", return_value=mock_run),
     ):
-        ns = parse("down", "--dry-run")
-        rc = _cmd_down(ns)
-    assert rc == EXIT_NOTHING_TO_DO
-    assert "Nothing to roll back" in capsys.readouterr().out
+        result = runner.invoke(cli, ["down", "--dry-run"])
+    assert result.exit_code == EXIT_NOTHING_TO_DO
+    assert "Nothing to roll back" in result.output
+
+
+def test_cmd_down_passes_transactional_false_by_default() -> None:
+    mock_run = MagicMock()
+    mock_run.down.return_value = []
+    with (
+        patch("mongrator.cli._load_config"),
+        patch("pymongo.MongoClient", return_value=MagicMock()),
+        patch("mongrator.runner.SyncRunner", return_value=mock_run),
+    ):
+        runner.invoke(cli, ["down"])
+    mock_run.down.assert_called_once_with(steps=1, transactional=False)
+
+
+def test_cmd_down_passes_transactional_true() -> None:
+    mock_run = MagicMock()
+    mock_run.down.return_value = []
+    with (
+        patch("mongrator.cli._load_config"),
+        patch("pymongo.MongoClient", return_value=MagicMock()),
+        patch("mongrator.runner.SyncRunner", return_value=mock_run),
+    ):
+        runner.invoke(cli, ["down", "--transactional"])
+    mock_run.down.assert_called_once_with(steps=1, transactional=True)
 
 
 # ---------------------------------------------------------------------------
@@ -515,33 +583,31 @@ def test_cmd_down_dry_run_nothing_to_rollback(capsys: pytest.CaptureFixture[str]
 # ---------------------------------------------------------------------------
 
 
-def test_cmd_validate_all_ok(capsys: pytest.CaptureFixture[str]) -> None:
-    mock_runner = MagicMock()
-    mock_runner.validate.return_value = []
+def test_cmd_validate_all_ok() -> None:
+    mock_run = MagicMock()
+    mock_run.validate.return_value = []
     with (
         patch("mongrator.cli._load_config"),
         patch("pymongo.MongoClient", return_value=MagicMock()),
-        patch("mongrator.runner.SyncRunner", return_value=mock_runner),
+        patch("mongrator.runner.SyncRunner", return_value=mock_run),
     ):
-        ns = parse("validate")
-        rc = _cmd_validate(ns)
-    assert rc == 0
-    assert "valid checksums" in capsys.readouterr().out
+        result = runner.invoke(cli, ["validate"])
+    assert result.exit_code == 0
+    assert "valid checksums" in result.output
 
 
-def test_cmd_validate_reports_mismatches(capsys: pytest.CaptureFixture[str]) -> None:
+def test_cmd_validate_reports_mismatches() -> None:
     errors = [ChecksumMismatchError("001_a", "expected", "actual")]
-    mock_runner = MagicMock()
-    mock_runner.validate.return_value = errors
+    mock_run = MagicMock()
+    mock_run.validate.return_value = errors
     with (
         patch("mongrator.cli._load_config"),
         patch("pymongo.MongoClient", return_value=MagicMock()),
-        patch("mongrator.runner.SyncRunner", return_value=mock_runner),
+        patch("mongrator.runner.SyncRunner", return_value=mock_run),
     ):
-        ns = parse("validate")
-        rc = _cmd_validate(ns)
-    assert rc == 1
-    assert "001_a" in capsys.readouterr().err
+        result = runner.invoke(cli, ["validate"])
+    assert result.exit_code == 1
+    assert "001_a" in result.stderr
 
 
 # ---------------------------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -440,6 +440,7 @@ name = "mongrator"
 version = "0.3.0"
 source = { editable = "." }
 dependencies = [
+    { name = "click" },
     { name = "pymongo" },
 ]
 
@@ -460,7 +461,10 @@ docs = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "pymongo", specifier = ">=4.10" }]
+requires-dist = [
+    { name = "click", specifier = ">=8.0" },
+    { name = "pymongo", specifier = ">=4.10" },
+]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
💁 These changes replace the argparse-based CLI with click. All existing behavior is preserved — same subcommands (init, create, status, up, down, validate), same options (--config, --target, --steps, --async, --dry-run), same exit codes, and same error handling. Tests are updated to use click's CliRunner. Adds click>=8.0 as a runtime dependency.