### PR TITLE
ci(test): report test coverage to Coveralls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,7 @@ jobs:
           --tb=short
           --junit-xml=reports/junit-unit.xml
           --cov=mongrator
+          --cov-data-file=reports/.coverage.unit
           --cov-report=term-missing
           --cov-report=xml:reports/coverage-unit.xml
 
@@ -75,6 +76,7 @@ jobs:
           --tb=short
           --junit-xml=reports/junit-integration.xml
           --cov=mongrator
+          --cov-data-file=reports/.coverage.integration
           --cov-report=term-missing
           --cov-report=xml:reports/coverage-integration.xml
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,22 +61,24 @@ jobs:
         run: uv sync --group dev
 
       - name: Unit tests
+        env:
+          COVERAGE_FILE: reports/.coverage.unit
         run: >-
           uv run pytest tests/unit/
           --tb=short
           --junit-xml=reports/junit-unit.xml
           --cov=mongrator
-          --cov-data-file=reports/.coverage.unit
           --cov-report=term-missing
           --cov-report=xml:reports/coverage-unit.xml
 
       - name: Integration tests
+        env:
+          COVERAGE_FILE: reports/.coverage.integration
         run: >-
           uv run pytest tests/integration/
           --tb=short
           --junit-xml=reports/junit-integration.xml
           --cov=mongrator
-          --cov-data-file=reports/.coverage.integration
           --cov-report=term-missing
           --cov-report=xml:reports/coverage-integration.xml
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,16 @@ jobs:
           --cov-report=term-missing
           --cov-report=xml:reports/coverage-integration.xml
 
+      - name: Combine coverage
+        run: |
+          uv run coverage combine reports/.coverage.unit reports/.coverage.integration
+          uv run coverage lcov -o reports/lcov.info
+
+      - name: Upload to Coveralls
+        uses: coverallsapp/github-action@5cbfd81b66ca5d10c19b062c04de0199c215fb6e # v2
+        with:
+          file: reports/lcov.info
+
       - name: Upload test reports
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,8 @@ wheels/
 # Documentation build output
 site/
 
+# Code coverage reporting output
+reports/
+
 # Coding agents
 .claude

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Python Versions](https://img.shields.io/pypi/pyversions/mongrator)](https://pypi.org/project/mongrator)
 [![Monthly Downloads](https://static.pepy.tech/badge/mongrator/month)](https://pepy.tech/project/mongrator)
 [![CI](https://github.com/sgerrand/pymongrator/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/sgerrand/pymongrator/actions/workflows/ci.yml)
+[![Coverage Status](https://coveralls.io/repos/github/sgerrand/pymongrator/badge.svg?branch=main)](https://coveralls.io/github/sgerrand/pymongrator?branch=main)
 
 Lightweight MongoDB schema migration tool with synchronous and asynchronous PyMongo support.
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![PyPI Version](https://img.shields.io/pypi/v/mongrator)](https://pypi.org/project/mongrator)
 [![Python Versions](https://img.shields.io/pypi/pyversions/mongrator)](https://pypi.org/project/mongrator)
 [![Monthly Downloads](https://static.pepy.tech/badge/mongrator/month)](https://pepy.tech/project/mongrator)
-[![CI](https://github.com/sgerrand/pymongrator/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/sgerrand/pymongrator/actions/workflows/ci.yml)
+[![Build Status](https://github.com/sgerrand/pymongrator/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/sgerrand/pymongrator/actions/workflows/ci.yml)
 [![Coverage Status](https://coveralls.io/repos/github/sgerrand/pymongrator/badge.svg?branch=main)](https://coveralls.io/github/sgerrand/pymongrator?branch=main)
 
 Lightweight MongoDB schema migration tool with synchronous and asynchronous PyMongo support.


### PR DESCRIPTION
💁 These changes integrate coveralls.io into the CI pipeline by combining unit and integration test coverage data and posting it to coveralls.io on every push and pull request.

## Changes

- Direct `pytest-cov` output to named data files (`reports/.coverage.unit`, `reports/.coverage.integration`) so they can be merged
- Add a **Combine coverage** step that merges the two data files and generates `reports/lcov.info` via `coverage lcov`
- Add an **Upload to Coveralls** step using `coverallsapp/github-action@v2` (pinned to commit SHA) with the combined LCOV report